### PR TITLE
fix: lazy auth and prevent credential leaking in all skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,8 +80,8 @@ description: Use when the user wants to <what this skill does>
 
 ---
 
-## Auth Gate
-<How to verify credentials before any operation>
+## Auth Approach
+<Lazy auth: do not check upfront, just run the command. Diagnose auth failures in Self-Healing>
 
 ## Tool Preference
 <What tools to use and in what priority order>
@@ -104,7 +104,7 @@ description: Use when the user wants to <what this skill does>
 
 Key principles:
 - **Exact commands** — show copy-pasteable commands, not pseudocode
-- **Auth gate is a hard stop** — no operations proceed without auth
+- **Auth is lazy** — attempt the operation first, diagnose auth failures in Self-Healing. Never print credential values.
 - **Prefer helpers over raw API** — if the CLI has convenience commands, use them
 - **Confirm before destructive ops** — always ask the user before delete operations
 - **Self-healing is critical** — tell Claude how to debug when things go wrong
@@ -164,3 +164,4 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh <skill> test
 - **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`.
 - **Skills are self-contained.** Each SKILL.md should contain everything Claude needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Tests run Claude in a subprocess.** Unit tests use `run_claude` with `--dangerously-skip-permissions`. Integration tests use `run_claude_logged` with `--output-format stream-json` to capture tool usage.
+- **Lazy auth, never print secrets.** Skills do not check authentication upfront. They attempt the operation and only diagnose auth issues when commands fail (in Self-Healing). Credentials, tokens, and API keys are NEVER printed or echoed — only check whether they are set (`test -n`), never display values.

--- a/plugins/atlassian/skills/confluence/SKILL.md
+++ b/plugins/atlassian/skills/confluence/SKILL.md
@@ -7,45 +7,11 @@ description: Use when the user wants to interact with Confluence — search page
 
 Interact with Confluence Cloud to search pages, read documentation, create or update content, and browse spaces.
 
-## Auth Gate
+## Auth Approach
 
-**You MUST confirm authentication before making any API calls.**
+Do NOT check authentication upfront. Just run the command. If it fails with an auth error, see the **Self-Healing** section for diagnostics.
 
-### Step 1 — Check env vars (PRIMARY — required for most operations)
-
-```bash
-echo "ATLASSIAN_DOMAIN=${ATLASSIAN_DOMAIN:-(not set)}"
-echo "ATLASSIAN_EMAIL=${ATLASSIAN_EMAIL:-(not set)}"
-echo "ATLASSIAN_API_TOKEN=${ATLASSIAN_API_TOKEN:-(not set)}"
-```
-
-All three must be set for curl-based operations. Since curl is the primary tool for Confluence, these are effectively required for any real workflow. **If env vars are set, you are good to proceed — do not wait for acli.**
-
-### Step 2 — Optionally check acli (supplementary only)
-
-```bash
-command -v acli && acli auth status
-```
-
-If available and authenticated, acli can supplement curl for a few operations (page view by ID, space list/view). But acli is **not required** and **not the primary tool** for Confluence.
-
-**Important: If acli is not installed or not authenticated, silently fall back to curl. Do NOT ask the user about acli setup. Do NOT stop or prompt — just use curl.**
-
-### If env vars are not set AND acli is not available — STOP
-
-Only stop if **neither** auth path works. Tell the user:
-
-> To use Confluence, set these environment variables:
->
-> ```bash
-> export ATLASSIAN_DOMAIN="yourcompany"        # yourcompany.atlassian.net
-> export ATLASSIAN_EMAIL="you@company.com"
-> export ATLASSIAN_API_TOKEN="your-token"
-> ```
->
-> Generate an API token at: https://id.atlassian.com/manage/api-tokens
-
-**Do not proceed without auth. This is a hard gate.**
+**NEVER print, echo, or log the values of `ATLASSIAN_API_TOKEN`, `ATLASSIAN_EMAIL`, or any credentials.** Only check whether they are set (e.g., `test -n`), never display their contents.
 
 ## Script Detection
 
@@ -308,7 +274,37 @@ See `storage-format.md` for the Confluence XHTML storage format reference, neede
 
 If an API call or acli command fails:
 
-1. Check the error message for clues (auth, permissions, bad request body, version conflict).
+### Auth Errors (401, 403, or "not authenticated")
+
+Check which auth paths are available — **never print token or credential values**:
+
+```bash
+# Check if env vars are set (NOT their values)
+test -n "${ATLASSIAN_DOMAIN:-}" && echo "ATLASSIAN_DOMAIN is set" || echo "ATLASSIAN_DOMAIN is NOT set"
+test -n "${ATLASSIAN_EMAIL:-}" && echo "ATLASSIAN_EMAIL is set" || echo "ATLASSIAN_EMAIL is NOT set"
+test -n "${ATLASSIAN_API_TOKEN:-}" && echo "ATLASSIAN_API_TOKEN is set" || echo "ATLASSIAN_API_TOKEN is NOT set"
+```
+
+```bash
+# Check acli (optional)
+command -v acli && acli auth status
+```
+
+If neither auth path is available, tell the user:
+
+> To use Confluence, set these environment variables:
+>
+> ```bash
+> export ATLASSIAN_DOMAIN="yourcompany"        # yourcompany.atlassian.net
+> export ATLASSIAN_EMAIL="you@company.com"
+> export ATLASSIAN_API_TOKEN="your-token"
+> ```
+>
+> Generate an API token at: https://id.atlassian.com/manage/api-tokens
+
+### Other Errors
+
+1. Check the error message for clues (permissions, bad request body, version conflict).
 2. For acli errors, run `acli confluence [command] --help` for current flags and syntax.
 3. If the API may have changed, check live docs via web search. Canonical URLs:
    - Confluence v2 REST API: `https://developer.atlassian.com/cloud/confluence/rest/v2/`

--- a/plugins/atlassian/skills/jira/SKILL.md
+++ b/plugins/atlassian/skills/jira/SKILL.md
@@ -9,45 +9,11 @@ Interact with Jira Cloud: search issues, create and update tickets, transition w
 
 ---
 
-## Auth Gate
+## Auth Approach
 
-You MUST confirm authentication before making any API calls. Run both checks in order.
+Do NOT check authentication upfront. Just run the command. If it fails with an auth error, see the **Self-Healing** section for diagnostics.
 
-### Check 1 — acli (preferred)
-
-```bash
-command -v acli && acli auth status
-```
-
-If both succeed, set `acli` as the preferred tool for this session. Skip to the **Tool Preference** section.
-
-**If acli is not installed or not authenticated, silently move to Check 2. Do NOT ask the user about acli setup — just try env vars.**
-
-### Check 2 — Environment variables (curl fallback)
-
-```bash
-test -n "$ATLASSIAN_DOMAIN" && test -n "$ATLASSIAN_EMAIL" && test -n "$ATLASSIAN_API_TOKEN" && echo "ENV OK"
-```
-
-If this succeeds, use curl as the tool for this session. Skip to the **Tool Preference** section.
-
-### Neither available — STOP
-
-Do not proceed. Tell the user:
-
-> I cannot connect to Jira. You need one of these:
->
-> **Option A (recommended):** Install and authenticate the Atlassian CLI:
-> ```
-> acli auth login
-> ```
->
-> **Option B:** Set these environment variables:
-> - `ATLASSIAN_DOMAIN` — your subdomain (e.g., `mycompany` for `mycompany.atlassian.net`)
-> - `ATLASSIAN_EMAIL` — your Atlassian account email
-> - `ATLASSIAN_API_TOKEN` — generate one at https://id.atlassian.com/manage/api-tokens
-
-This is a hard gate. No API calls without auth.
+**NEVER print, echo, or log the values of `ATLASSIAN_API_TOKEN`, `ATLASSIAN_EMAIL`, or any credentials.** Only check whether they are set (e.g., `test -n`), never display their contents.
 
 ---
 
@@ -418,6 +384,38 @@ ADF is **only needed when using raw curl** for write operations (create issue de
 ## Self-Healing
 
 When an API call or acli command fails:
+
+### Auth Errors (401, 403, or "not authenticated")
+
+Check which auth paths are available — **never print token or credential values**:
+
+```bash
+# Check if acli is available and authenticated
+command -v acli && acli auth status
+```
+
+```bash
+# Check if env vars are set (NOT their values)
+test -n "${ATLASSIAN_DOMAIN:-}" && echo "ATLASSIAN_DOMAIN is set" || echo "ATLASSIAN_DOMAIN is NOT set"
+test -n "${ATLASSIAN_EMAIL:-}" && echo "ATLASSIAN_EMAIL is set" || echo "ATLASSIAN_EMAIL is NOT set"
+test -n "${ATLASSIAN_API_TOKEN:-}" && echo "ATLASSIAN_API_TOKEN is set" || echo "ATLASSIAN_API_TOKEN is NOT set"
+```
+
+If neither auth path is available, tell the user:
+
+> I cannot connect to Jira. You need one of these:
+>
+> **Option A (recommended):** Install and authenticate the Atlassian CLI:
+> ```
+> acli auth login
+> ```
+>
+> **Option B:** Set these environment variables:
+> - `ATLASSIAN_DOMAIN` — your subdomain (e.g., `mycompany` for `mycompany.atlassian.net`)
+> - `ATLASSIAN_EMAIL` — your Atlassian account email
+> - `ATLASSIAN_API_TOKEN` — generate one at https://id.atlassian.com/manage/api-tokens
+
+### Other Errors
 
 1. **For acli errors:** check `acli [command] --help` for current flags and syntax
 2. **For REST API errors:** check the response body for error details and verify the endpoint

--- a/plugins/google-workspace/skills/calendar/SKILL.md
+++ b/plugins/google-workspace/skills/calendar/SKILL.md
@@ -9,15 +9,9 @@ View agenda, create and manage events, check availability, and manage calendars 
 
 ---
 
-## Auth Gate
+## Auth Approach
 
-Before any operation, verify the gws CLI is available and authenticated:
-
-1. Check gws is on PATH: `which gws`
-2. Check auth is valid: `gws auth status`
-
-If either check fails, stop and tell the user:
-> "The gws CLI is not installed or not authenticated. Install and configure it: https://github.com/googleworkspace/cli"
+Do NOT check authentication upfront. Just run the command. If it fails with an auth error (exit code 2), see the **Self-Healing** section for diagnostics.
 
 ---
 
@@ -143,11 +137,23 @@ See `calendar-recipes.md`
 
 When a command fails:
 
+### Auth Errors (exit code 2)
+
+Check if gws is available and authenticated:
+
+```bash
+which gws && gws auth status
+```
+
+If gws is not installed or not authenticated, tell the user:
+> "The gws CLI is not installed or not authenticated. Install and configure it: https://github.com/googleworkspace/cli"
+
+### Other Errors
+
 - Check the command's help: `gws calendar <command> --help`
 - Inspect the API schema: `gws schema calendar.<resource>.<method>`
 - Use `--dry-run` to preview requests without executing
 - Exit codes: 0=success, 1=API error, 2=auth error, 3=validation, 4=discovery, 5=internal
-- Auth errors (exit 2): re-run `gws auth status` and direct user to https://github.com/googleworkspace/cli
 - Validation errors (exit 3): check `--params` JSON syntax and required fields
 
 ---

--- a/plugins/google-workspace/skills/gmail/SKILL.md
+++ b/plugins/google-workspace/skills/gmail/SKILL.md
@@ -9,15 +9,9 @@ Search, read, send, and manage Gmail messages, drafts, labels, and filters using
 
 ---
 
-## Auth Gate
+## Auth Approach
 
-Before any operation, verify the gws CLI is available and authenticated:
-
-1. Check gws is on PATH: `which gws`
-2. Check auth is valid: `gws auth status`
-
-If either check fails, stop and tell the user:
-> "The gws CLI is not installed or not authenticated. Install and configure it: https://github.com/googleworkspace/cli"
+Do NOT check authentication upfront. Just run the command. If it fails with an auth error (exit code 2), see the **Self-Healing** section for diagnostics.
 
 ---
 
@@ -155,11 +149,23 @@ See `gmail-search-recipes.md`
 
 When a command fails:
 
+### Auth Errors (exit code 2)
+
+Check if gws is available and authenticated:
+
+```bash
+which gws && gws auth status
+```
+
+If gws is not installed or not authenticated, tell the user:
+> "The gws CLI is not installed or not authenticated. Install and configure it: https://github.com/googleworkspace/cli"
+
+### Other Errors
+
 - Check the command's help: `gws gmail <command> --help`
 - Inspect the API schema: `gws schema gmail.<resource>.<method>`
 - Use `--dry-run` to preview requests without executing
 - Exit codes: 0=success, 1=API error, 2=auth error, 3=validation, 4=discovery, 5=internal
-- Auth errors (exit 2): re-run `gws auth status` and direct user to https://github.com/googleworkspace/cli
 - Validation errors (exit 3): check `--params` JSON syntax and required fields
 
 ---

--- a/tests/unit/test-calendar-skill.sh
+++ b/tests/unit/test-calendar-skill.sh
@@ -10,7 +10,7 @@ echo "=== Test: calendar skill ==="
 echo ""
 
 # Test 1: Skill recognition and auth
-echo "Test 1: Skill loading and auth gate..."
+echo "Test 1: Skill loading and auth approach..."
 
 output=$(run_claude "What is the calendar skill? Describe its authentication requirements briefly." 30)
 

--- a/tests/unit/test-confluence-skill.sh
+++ b/tests/unit/test-confluence-skill.sh
@@ -10,7 +10,7 @@ echo "=== Test: confluence skill ==="
 echo ""
 
 # Test 1: Skill recognition and auth
-echo "Test 1: Skill loading and auth gate..."
+echo "Test 1: Skill loading and auth approach..."
 
 output=$(run_claude "What is the confluence skill? Describe its authentication requirements briefly." 30)
 

--- a/tests/unit/test-gmail-skill.sh
+++ b/tests/unit/test-gmail-skill.sh
@@ -10,7 +10,7 @@ echo "=== Test: gmail skill ==="
 echo ""
 
 # Test 1: Skill recognition and auth
-echo "Test 1: Skill loading and auth gate..."
+echo "Test 1: Skill loading and auth approach..."
 
 output=$(run_claude "What is the gmail skill? Describe its authentication requirements briefly." 30)
 

--- a/tests/unit/test-jira-skill.sh
+++ b/tests/unit/test-jira-skill.sh
@@ -10,7 +10,7 @@ echo "=== Test: jira skill ==="
 echo ""
 
 # Test 1: Skill recognition and auth
-echo "Test 1: Skill loading and auth gate..."
+echo "Test 1: Skill loading and auth approach..."
 
 output=$(run_claude "What is the jira skill? Describe its authentication requirements briefly." 30)
 


### PR DESCRIPTION
## Summary

- Remove upfront auth gates from all 4 skills (Jira, Confluence, Gmail, Calendar) — commands are attempted directly, auth is only diagnosed on failure via Self-Healing
- Fix Confluence skill that was echoing raw `ATLASSIAN_API_TOKEN` and `ATLASSIAN_EMAIL` values into the conversation
- Update CLAUDE.md skill template and key principles to reflect the lazy auth pattern

## Test plan

- [ ] Verify no `echo` of credential values in any SKILL.md
- [ ] Verify each skill's Self-Healing section covers auth error diagnostics
- [ ] Verify CLAUDE.md template uses "Auth Approach" instead of "Auth Gate"
- [ ] Run unit tests: `PLUGIN_DIR=plugins/atlassian bash tests/unit/test-jira-skill.sh`