### PR TITLE
feat: add research plugin with deep-research agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,6 +15,12 @@
       "source": "./plugins/google-workspace",
       "description": "Google Workspace skills (Gmail, Calendar) powered by the gws CLI",
       "version": "1.0.0"
+    },
+    {
+      "name": "research",
+      "source": "./plugins/research",
+      "description": "Deep research and prompt generation — conduct comprehensive web research with multi-perspective analysis, or craft optimized research prompts for external AI tools",
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,6 +11,8 @@ plugins/
   <plugin-name>/
     .claude-plugin/
       plugin.json           # Plugin metadata (name, description, author, license, keywords)
+    agents/                 # Optional: agent definitions for long-running isolated tasks
+      <agent-name>.md
     scripts/                # Optional wrapper scripts (if the CLI needs abstraction)
       _common.sh            # Shared helpers (auth, curl wrappers, etc.)
       <service>/            # Per-service scripts
@@ -33,6 +35,7 @@ tests/
 |--------|---------|--------|
 | `atlassian` | 1.2.0 | `jira`, `confluence` |
 | `google-workspace` | 1.0.0 | `gmail`, `calendar` |
+| `research` | 1.0.0 | `research` (+ `deep-research` agent) |
 
 ## How to Develop a New Skill
 
@@ -164,3 +167,4 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh <skill> test
 - **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`.
 - **Skills are self-contained.** Each SKILL.md should contain everything Claude needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Tests run Claude in a subprocess.** Unit tests use `run_claude` with `--dangerously-skip-permissions`. Integration tests use `run_claude_logged` with `--output-format stream-json` to capture tool usage.
+- **Agents for long-running, context-heavy operations.** When a skill's execution would consume significant context (e.g. dozens of web pages for research), define an agent in `agents/` and have the skill dispatch it via the Agent tool. The agent runs in an isolated subagent context. Use skills for everything else.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Gmail and Calendar skills for Google Workspace — powered by the `gws` CLI.
 Comprehensive web research with multi-perspective analysis, or optimized prompt generation for external AI tools.
 
 **Skills:**
-- `/spycner-tools:research` — Deep web research with source synthesis, fact-checking, and structured reports
-- `/spycner-tools:deep-research` — Generate optimized prompts for external AI research tools (e.g. Perplexity, Gemini)
+- `/spycner-tools:research` — Research intake, refinement, and routing. Conducts deep web research with multi-perspective analysis and structured reports, or generates optimized prompts for external AI tools (OpenAI, Gemini, Perplexity). Dispatches a `deep-research` agent for execution.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,21 @@ Gmail and Calendar skills for Google Workspace — powered by the `gws` CLI.
 - `/spycner-tools:gmail` — Search, read, send, and manage Gmail messages, drafts, labels, and filters
 - `/spycner-tools:calendar` — View agenda, create and manage events, check availability, manage calendars
 
+### research
+
+Comprehensive web research with multi-perspective analysis, or optimized prompt generation for external AI tools.
+
+**Skills:**
+- `/spycner-tools:research` — Deep web research with source synthesis, fact-checking, and structured reports
+- `/spycner-tools:deep-research` — Generate optimized prompts for external AI research tools (e.g. Perplexity, Gemini)
+
 ## Installation
 
 ```
 /plugin marketplace add Spycner/spycner-tools
 /plugin install atlassian@spycner-tools
 /plugin install google-workspace@spycner-tools
+/plugin install research@spycner-tools
 ```
 
 ## Setup
@@ -60,3 +69,7 @@ gws auth login -s gmail,calendar
 ```
 
 For full setup instructions, see: https://github.com/googleworkspace/cli
+
+### Research Plugin
+
+No authentication required. The research plugin uses WebSearch and WebFetch which work out of the box.

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "research",
+  "description": "Deep research and prompt generation for comprehensive web investigations",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["research", "deep-research", "web-research", "report", "citations", "prompt-engineering"]
+}

--- a/plugins/research/agents/deep-research.md
+++ b/plugins/research/agents/deep-research.md
@@ -26,11 +26,11 @@ Then proceed immediately to the next phase (do not wait for approval — the pla
 
 Identify 3-5 stakeholder perspectives relevant to the topic. Save to `{output-path}/research/perspectives.md`.
 
-Think about: practitioners, decision-makers, regulators, researchers, critics, end users, economists. Pick the most relevant ones. See research-recipes.md for patterns.
+Think about: practitioners, decision-makers, regulators, researchers, critics, end users, economists. Pick the most relevant ones. See skills/research/research-recipes.md for patterns.
 
 ### Phase 3: Breadth Pass
 
-For each sub-question + perspective combination, run 3-5 WebSearch queries from different angles (academic, industry, critical, adoption, future). See research-recipes.md for query patterns.
+For each sub-question + perspective combination, run 3-5 WebSearch queries from different angles (academic, industry, critical, adoption, future). See skills/research/research-recipes.md for query patterns.
 
 In quick mode: 2-3 searches per sub-question, no perspective combinations.
 
@@ -65,7 +65,7 @@ Before writing, self-audit (see research-recipes.md for full checklist):
 
 If audit fails, go back to the relevant phase. Maximum 2 retry iterations per phase.
 
-Write the final report to `{output-path}/report.md` using the appropriate template from report-template.md.
+Write the final report to `{output-path}/report.md` using the appropriate template from skills/research/report-template.md.
 
 ## Output Structure
 

--- a/plugins/research/agents/deep-research.md
+++ b/plugins/research/agents/deep-research.md
@@ -1,0 +1,95 @@
+---
+name: deep-research
+description: Conducts comprehensive web research with multi-perspective analysis and produces detailed reports with citations
+tools: WebSearch, WebFetch, Read, Write, Bash
+---
+
+# Deep Research Agent
+
+You are a research agent that conducts comprehensive investigations and produces well-cited reports. You receive a refined research query, mode (deep/quick), output path, and constraints from the research intake skill.
+
+## Critical Workflow
+
+Execute these phases in order. Each phase produces an intermediate artifact — do not skip phases or combine them.
+
+### Phase 1: Research Plan
+
+Generate a structured plan and save to `{output-path}/research/plan.md`:
+
+- List 3-5 sub-questions to investigate
+- For each sub-question: 2-3 search angles
+- Source types to target (academic, industry, news, etc.)
+
+Then proceed immediately to the next phase (do not wait for approval — the plan is saved as an artifact for the user to review after).
+
+### Phase 2: Perspective Discovery (deep mode only)
+
+Identify 3-5 stakeholder perspectives relevant to the topic. Save to `{output-path}/research/perspectives.md`.
+
+Think about: practitioners, decision-makers, regulators, researchers, critics, end users, economists. Pick the most relevant ones. See research-recipes.md for patterns.
+
+### Phase 3: Breadth Pass
+
+For each sub-question + perspective combination, run 3-5 WebSearch queries from different angles (academic, industry, critical, adoption, future). See research-recipes.md for query patterns.
+
+In quick mode: 2-3 searches per sub-question, no perspective combinations.
+
+Collect URLs, titles, key quotes, and publication dates. Save to `{output-path}/research/sources.md`.
+
+### Phase 4: Depth Pass
+
+Fetch full content from the most promising sources using WebFetch. Extract:
+- Specific data points and statistics
+- Direct quotes with attribution
+- Methodology details
+- Findings that answer the sub-questions
+
+Save extractions to `{output-path}/research/notes.md`. When fetching, extract only relevant sections — do not load entire documents into context.
+
+### Phase 5: Adversarial Pass (deep mode only)
+
+Explicitly search for counterarguments, limitations, and criticism of the findings so far. Look for:
+- Conflicting data or dissenting experts
+- Retractions, corrections, or updated findings
+- Methodological criticisms of cited studies
+
+Append findings to `{output-path}/research/notes.md`.
+
+### Phase 6: Synthesis & Report
+
+Before writing, self-audit (see research-recipes.md for full checklist):
+- Does every section have at least one specific data point or quote?
+- Did I represent a perspective I find unconvincing?
+- Could someone fact-check this report from my citations alone?
+- Does sources.md have 8+ entries? (If fewer, go back to Phase 3 with broader queries)
+
+If audit fails, go back to the relevant phase. Maximum 2 retry iterations per phase.
+
+Write the final report to `{output-path}/report.md` using the appropriate template from report-template.md.
+
+## Output Structure
+
+```
+{output-path}/
+  report.md
+  research/
+    plan.md
+    perspectives.md    (deep mode only)
+    sources.md
+    notes.md
+```
+
+Create the output directory and research/ subdirectory if they don't exist.
+
+## Self-Healing
+
+- **WebSearch returns no results:** Broaden query, try alternative terms, remove constraints. After 2 retries with no results for a specific angle, note the gap in notes.md and move on.
+- **WebFetch fails on a URL:** Skip it, note as inaccessible in sources.md, try alternative sources. Do not block the entire pass on one failed fetch.
+- **Context getting large:** Summarize extracted content in notes.md and drop raw content from working memory. Depth of analysis > breadth of raw material.
+
+## Behavioral Guidelines
+
+- Start each phase by reviewing previous phase artifacts to avoid redundant work
+- Prefer authoritative sources: academic papers for science, industry reports for markets, official docs for technical topics
+- Weight recent sources (last 2 years) more heavily for evolving topics, but note the temporal limitation
+- Always attribute: "According to [Source]..." — never "Studies show..." without citation

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: research
+description: Use when the user wants to research a topic, investigate something, conduct a deep dive, find sources and citations, write a research report, or craft an optimized research prompt for external AI tools like OpenAI or Gemini. Triggers on research intent — not simple factual questions Claude can answer directly.
+---
+
+# Research Skill
+
+Universal entry point for all research requests. Refines the user's intent, then either dispatches the deep-research agent or generates an optimized prompt for external tools.
+
+---
+
+## Auth Approach
+
+No authentication required. Uses WebSearch and WebFetch (no credentials needed) and writes to the local filesystem.
+
+## Tool Preference
+
+1. **Agent tool** — to dispatch the deep-research agent for execution
+2. **WebSearch** — for inline research if agent dispatch fails
+3. **WebFetch** — for inline content retrieval if agent dispatch fails
+4. **Write** — for saving prompts to file when requested
+5. **Read** — for reading the agent definition and reference files
+6. **Bash** — for directory creation and date generation
+
+## Workflow
+
+### Step 1: Clarify
+
+Ask scoping questions one at a time or in small batches:
+- Main research questions / what specifically to explore
+- Timeframe (last 2 years? historical?)
+- Geographic scope (if relevant)
+- Audience (who will read this?)
+- Purpose (what decisions will this inform?)
+- Source preferences (academic, industry, news, docs)
+- Specific angles, perspectives, or controversies to explore
+
+If the request is already clearly scoped (e.g. "research the impact of tariffs on EU automotive exports since 2024"), skip redundant questions — just confirm scope and proceed.
+
+### Step 2: Route
+
+Once intent is clear, ask: "Should I run this research now, or generate an optimized prompt you can use in another tool (OpenAI, Gemini, etc.)?"
+
+- **Run now** → proceed to Step 3 (dispatch agent)
+- **Generate prompt** → proceed to Prompt Output section below
+
+### Step 3: Configure & Dispatch
+
+Before dispatching, allow overrides:
+- **Output path** — default: `reports/{topic-slug}-{YYYY-MM-DD}/`
+- **Mode** — deep (default) or quick
+
+Default to deep mode unless the user signals quick: "quick look at", "brief overview of", "what's the deal with".
+
+Then dispatch the deep-research agent:
+
+1. Read `agents/deep-research.md` from this plugin directory
+2. Use the **Agent tool** to spawn a subagent with a prompt containing:
+   - The refined research query
+   - The selected mode (deep/quick)
+   - The output path (absolute)
+   - Any user-specified constraints (timeframe, source preferences, etc.)
+3. When the agent completes, report the output path and a brief summary to the user
+
+## Prompt Output
+
+When the user wants a prompt for external tools, generate a structured prompt:
+
+```
+### TASK
+[Clear, specific research objective]
+
+### CONTEXT/BACKGROUND
+[Why this matters and how it will be used]
+
+### SPECIFIC QUESTIONS OR SUBTASKS
+1. [First specific question]
+2. [Second specific question]
+...
+
+### KEYWORDS
+[Relevant search terms and concepts]
+
+### CONSTRAINTS
+- Timeframe: [specified timeframe]
+- Geography: [specified scope]
+- Source Types: [preferred sources]
+
+### OUTPUT FORMAT
+[Preferred format with specific requirements]
+
+### FINAL INSTRUCTIONS
+Remain concise, reference sources accurately, and provide evidence-based analysis.
+```
+
+Output directly in conversation. Optionally save to a file if the user requests it.
+
+## Self-Healing
+
+- **Agent dispatch fails:** Fall back to running the research workflow inline (in the main conversation). Warn the user that context may get heavy. Follow the same phases described in the agent definition.
+- **User changes mind mid-research:** The agent runs independently. They can start a new research request with revised scope.
+- **Output directory not writable:** Check permissions, suggest an alternative path, or ask the user where to save.
+
+## Behavioral Guidelines
+
+- Trigger on research intent (investigate, deep dive, report, sources) — not simple factual questions Claude can answer from training data
+- When in doubt: "Would you like me to do a thorough research investigation, or just answer from what I know?"
+- If the user asks for both a research run AND a prompt, do both — run the agent and also output the prompt
+- See `report-template.md` for report structure and `research-recipes.md` for search patterns

--- a/plugins/research/skills/research/report-template.md
+++ b/plugins/research/skills/research/report-template.md
@@ -1,0 +1,69 @@
+# Report Templates
+
+## Deep Mode Report
+
+Use this structure for deep mode reports:
+
+# {Title}
+
+*Date: {YYYY-MM-DD}*
+
+## Executive Summary
+3-4 paragraphs: key findings, implications, recommendations
+
+## Table of Contents
+
+## Introduction
+Context, importance, scope of research
+
+## Methodology
+Research approach, perspectives consulted, source types, limitations
+
+## Key Findings
+### {Subtopic per sub-question/perspective}
+Detailed findings with inline citations
+
+## Analysis & Insights
+Synthesis across perspectives, patterns identified, implications
+
+## Counterarguments & Limitations
+Adversarial findings, dissenting views, gaps in research
+
+## Future Outlook
+Trends, predictions, areas for further research
+
+## Conclusions
+Summary of main points, actionable recommendations
+
+## References
+All sources with URLs and access dates
+
+---
+
+## Quick Mode Report
+
+Use this structure for quick mode reports:
+
+# {Title}
+
+*Date: {YYYY-MM-DD}*
+
+## Executive Summary
+2-3 paragraphs: key findings and takeaways
+
+## Key Findings
+### {Subtopic}
+Findings with inline citations
+
+## References
+All sources with URLs
+
+---
+
+## Citation Style
+
+- Inline citations with links: "According to [Source Name](URL), ..."
+- Include publication dates when available
+- Format: `[Author/Organization, Year](URL)` or `[Article Title - Publisher](URL)`
+- Every non-obvious claim must have a citation
+- Key claims cross-referenced (2+ independent sources)

--- a/plugins/research/skills/research/research-recipes.md
+++ b/plugins/research/skills/research/research-recipes.md
@@ -1,0 +1,52 @@
+# Research Recipes
+
+## Search Strategy Patterns
+
+### Breadth Pass Queries
+
+For each sub-question, vary the query framing across these angles:
+
+| Angle | Query Pattern | Example |
+|-------|--------------|---------|
+| Academic | "{topic} research papers {year}" | "remote work productivity research papers 2025" |
+| Industry | "{topic} industry analysis report" | "remote work industry analysis report" |
+| Critical | "{topic} challenges limitations criticism" | "remote work challenges limitations criticism" |
+| Adoption | "{topic} trends adoption statistics" | "remote work trends adoption statistics" |
+| Future | "{topic} future predictions outlook" | "remote work future predictions outlook" |
+
+### Adversarial Pass Queries
+
+| Pattern | Example |
+|---------|---------|
+| "{topic} criticism problems" | "remote work criticism problems" |
+| "{topic} failed why" | "remote work policies failed why" |
+| "{topic} risks downsides" | "remote work risks downsides" |
+| "{topic} debunked myth" | "remote work productivity debunked myth" |
+| "{previous finding} contradicted" | "remote work increases productivity contradicted" |
+
+## Perspective Discovery Patterns
+
+For any research topic, consider these stakeholder categories:
+
+| Category | Think about... |
+|----------|---------------|
+| Practitioners | People who do the thing daily |
+| Decision-makers | People who decide whether/how to adopt |
+| Regulators | People who govern or constrain |
+| Researchers | People who study it academically |
+| Critics | People who oppose or question it |
+| End users | People affected by the outcomes |
+| Economists | People who analyze costs/benefits |
+
+Not all categories apply to every topic. Pick 3-5 that are most relevant.
+
+## Self-Audit Checklist
+
+Before synthesis, verify:
+
+- [ ] Every section has at least one specific data point or direct quote
+- [ ] At least one perspective you personally find unconvincing is represented
+- [ ] Someone could fact-check this report using only the provided citations
+- [ ] sources.md has 8+ entries (if fewer, breadth pass was too narrow — go back)
+- [ ] Key claims have 2+ independent sources
+- [ ] Recent sources (last 2 years) are prioritized where the topic is evolving

--- a/tests/integration/test-research-integration.sh
+++ b/tests/integration/test-research-integration.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Integration test: research skill (quick mode)
+# Tests the full quick-mode research cycle on a simple topic
+# NOTE: This test makes real web searches — run sparingly
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+echo "=== Integration Test: research skill (quick mode) ==="
+echo ""
+
+# Use a temp directory for output — use a fixed subdir name to avoid slug mismatches
+TEST_OUTPUT_DIR=$(mktemp -d)
+REPORT_DIR="$TEST_OUTPUT_DIR/test-output"
+trap 'rm -rf "$TEST_OUTPUT_DIR"' EXIT
+
+LOG_FILE=$(mktemp)
+
+echo "Test 1: Quick-mode research cycle..."
+echo "  Output dir: $REPORT_DIR"
+
+output=$(run_claude_logged \
+    "Do a quick research on the history of markdown syntax. Save the report to $REPORT_DIR/. Use quick mode — I just need a brief overview with a few sources." \
+    "$LOG_FILE" \
+    180)
+
+echo ""
+
+# Check intermediate artifacts
+echo "Test 2: Verify intermediate artifacts..."
+
+if [ -d "$REPORT_DIR" ]; then
+    echo "  [PASS] Report directory created"
+else
+    echo "  [FAIL] Report directory not found at $REPORT_DIR"
+    echo "  Contents of output dir:"
+    ls -la "$TEST_OUTPUT_DIR" 2>/dev/null | sed 's/^/    /' || echo "    (empty)"
+fi
+
+if [ -f "$REPORT_DIR/research/plan.md" ]; then
+    echo "  [PASS] research/plan.md exists"
+else
+    echo "  [FAIL] research/plan.md not found"
+fi
+
+if [ -f "$REPORT_DIR/research/sources.md" ]; then
+    echo "  [PASS] research/sources.md exists"
+else
+    echo "  [FAIL] research/sources.md not found"
+fi
+
+if [ -f "$REPORT_DIR/research/notes.md" ]; then
+    echo "  [PASS] research/notes.md exists"
+else
+    echo "  [FAIL] research/notes.md not found"
+fi
+
+echo ""
+
+# Check final report
+echo "Test 3: Verify report..."
+
+if [ -f "$REPORT_DIR/report.md" ]; then
+    echo "  [PASS] report.md exists"
+    assert_contains "$(cat "$REPORT_DIR/report.md")" "Executive Summary|executive summary" "Report has Executive Summary" || true
+    assert_contains "$(cat "$REPORT_DIR/report.md")" "Key Findings|key findings" "Report has Key Findings" || true
+    assert_contains "$(cat "$REPORT_DIR/report.md")" "References|references|Sources|sources" "Report has References" || true
+    assert_contains "$(cat "$REPORT_DIR/report.md")" "http|https" "Report contains citation URLs" || true
+else
+    echo "  [FAIL] report.md not found"
+fi
+
+echo ""
+
+# Test 4: Configurable output path
+echo "Test 4: Custom output path..."
+
+CUSTOM_DIR="$TEST_OUTPUT_DIR/custom-output"
+LOG_FILE_2=$(mktemp)
+
+output=$(run_claude_logged \
+    "Do a quick research on what JSON is. Save to $CUSTOM_DIR/. Quick mode." \
+    "$LOG_FILE_2" \
+    180)
+
+if [ -d "$CUSTOM_DIR" ]; then
+    echo "  [PASS] Custom output path created"
+else
+    echo "  [FAIL] Custom output path not found at $CUSTOM_DIR"
+fi
+
+if [ -f "$CUSTOM_DIR/report.md" ]; then
+    echo "  [PASS] report.md exists in custom path"
+else
+    echo "  [FAIL] report.md not found in custom path"
+fi
+
+echo ""
+
+# Show tools used
+echo "Test 5: Tool usage..."
+show_tools_used "$LOG_FILE"
+
+echo ""
+echo "=== research integration tests complete ==="

--- a/tests/skill-triggering/prompts/research-deep-dive.txt
+++ b/tests/skill-triggering/prompts/research-deep-dive.txt
@@ -1,0 +1,1 @@
+Do a deep dive into the current state of quantum computing — what are the latest breakthroughs, who are the key players, and what's the realistic timeline for practical applications?

--- a/tests/skill-triggering/prompts/research-investigate.txt
+++ b/tests/skill-triggering/prompts/research-investigate.txt
@@ -1,0 +1,1 @@
+I need to investigate how other mid-size SaaS companies handle SOC2 compliance. What tools do they use, what does the audit process look like, and what are the common pitfalls?

--- a/tests/skill-triggering/prompts/research-negative-factual.txt
+++ b/tests/skill-triggering/prompts/research-negative-factual.txt
@@ -1,0 +1,1 @@
+What's the capital of France?

--- a/tests/skill-triggering/prompts/research-negative-knowledge.txt
+++ b/tests/skill-triggering/prompts/research-negative-knowledge.txt
@@ -1,0 +1,1 @@
+Explain how OAuth2 authorization code flow works step by step.

--- a/tests/skill-triggering/prompts/research-prompt-gen.txt
+++ b/tests/skill-triggering/prompts/research-prompt-gen.txt
@@ -1,0 +1,1 @@
+Help me craft a research prompt about renewable energy adoption in Southeast Asia that I can use with Gemini's deep research feature.

--- a/tests/skill-triggering/prompts/research-report.txt
+++ b/tests/skill-triggering/prompts/research-report.txt
@@ -1,0 +1,1 @@
+Can you research and write a report on remote work trends in 2025-2026? I want to understand how companies are adjusting their policies post-pandemic and what the data says about productivity.

--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -24,9 +24,9 @@ fi
 if command -v gtimeout &>/dev/null; then _to=gtimeout; elif command -v timeout &>/dev/null; then _to=timeout; else _to=""; fi
 
 if [ -n "$_to" ]; then
-    "$_to" 60 bash -c "claude -p \"$PROMPT\" $local_plugin_flag --output-format stream-json" > "$LOG_FILE" 2>&1 || true
+    "$_to" 60 bash -c "claude -p \"$PROMPT\" $local_plugin_flag --verbose --output-format stream-json" > "$LOG_FILE" 2>&1 || true
 else
-    bash -c "claude -p \"$PROMPT\" $local_plugin_flag --output-format stream-json" > "$LOG_FILE" 2>&1 || true
+    bash -c "claude -p \"$PROMPT\" $local_plugin_flag --verbose --output-format stream-json" > "$LOG_FILE" 2>&1 || true
 fi
 
 # Check if the skill was triggered

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -193,7 +193,7 @@ show_tools_used() {
     local log_file="$1"
     echo "  Tools used:"
     # Extract tool names from tool_use blocks
-    grep -oE '"name":"(Bash|Read|Write|Edit|Glob|Grep|Skill)"' "$log_file" 2>/dev/null | sort | uniq -c | sed 's/"name":"//;s/"$//;s/^/    /' || true
+    grep -oE '"name":"(Bash|Read|Write|Edit|Glob|Grep|Skill|WebSearch|WebFetch|Agent)"' "$log_file" 2>/dev/null | sort | uniq -c | sed 's/"name":"//;s/"$//;s/^/    /' || true
     # Show bash commands that reference scripts or acli or curl
     echo "  Commands:"
     grep -oE 'scripts/(jira|confluence)/[a-z_-]+\.sh' "$log_file" 2>/dev/null | sort -u | sed 's/^/    - script: /' || true

--- a/tests/unit/test-research-skill.sh
+++ b/tests/unit/test-research-skill.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test: research skill
+# Verifies the skill is loaded and describes correct capabilities
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+echo "=== Test: research skill ==="
+echo ""
+
+# Test 1: Skill recognition
+echo "Test 1: Skill loading and recognition..."
+
+output=$(run_claude "What is the research skill? Describe what it does briefly." 30)
+
+assert_contains "$output" "research|Research" "Skill is recognized" || true
+assert_contains "$output" "web.*search|WebSearch|investigate|deep dive" "Mentions web research capability" || true
+
+echo ""
+
+# Test 2: Tool preference
+echo "Test 2: Tool preference..."
+
+output=$(run_claude "In the research skill, what tools does it use? What is the primary execution mechanism?" 30)
+
+assert_contains "$output" "WebSearch|web search" "Mentions WebSearch" || true
+assert_contains "$output" "WebFetch|web fetch|fetch" "Mentions WebFetch" || true
+assert_contains "$output" "agent|Agent|subagent" "Mentions agent dispatch" || true
+
+echo ""
+
+# Test 3: Workflow coverage
+echo "Test 3: Workflow coverage..."
+
+output=$(run_claude "What workflow does the research skill follow? What are the main steps?" 30)
+
+assert_contains "$output" "clarif|scope|question" "Mentions clarification step" || true
+assert_contains "$output" "route|dispatch|prompt" "Mentions routing decision" || true
+assert_contains "$output" "deep|quick|mode" "Mentions research modes" || true
+
+echo ""
+
+# Test 4: Supporting references
+echo "Test 4: Supporting references..."
+
+output=$(run_claude "Does the research skill reference any supporting files? What templates or recipes does it use?" 30)
+
+assert_contains "$output" "template|report" "Mentions report template" || true
+assert_contains "$output" "recipe|pattern|strateg" "Mentions research recipes" || true
+
+echo ""
+
+echo "=== research skill tests complete ==="


### PR DESCRIPTION
## Summary

- Adds a new `research` plugin with an intake skill that refines research intent, then either dispatches a `deep-research` agent for comprehensive web research or generates optimized prompts for external AI tools (OpenAI, Gemini, Perplexity)
- The deep-research agent runs a 6-phase pipeline: research plan → perspective discovery → breadth pass → depth pass → adversarial pass → synthesis & report
- Supports deep (default) and quick modes, configurable output paths, and produces intermediate artifacts (plan, perspectives, sources, notes) alongside the final report
- Introduces the `agents/` directory convention for long-running, context-heavy operations that benefit from subagent isolation

## Test Plan

- [x] Unit tests: skill recognition, tool preference, workflow coverage, supporting references (10/10 pass)
- [x] Skill triggering: 4 positive prompts trigger correctly, 2 negative prompts correctly ignored
- [x] Integration test: full quick-mode research cycle produces report with Executive Summary, Key Findings, References, citation URLs, and all intermediate artifacts
- [x] Integration test: configurable output path works
- [x] Fix: skill-triggering runner now passes `--verbose` with `--output-format stream-json`