### PR TITLE
chore: rename project from spycner-tools to pgoell-claude-tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "spycner-tools",
+  "name": "pgoell-claude-tools",
   "owner": {
     "name": "Pascal Kraus"
   },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# spycner-tools
+# pgoell-claude-tools
 
 A Claude Code plugin marketplace containing skill plugins for external services.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spycner-tools
+# pgoell-claude-tools
 
 A personal Claude Code plugin marketplace.
 
@@ -9,31 +9,31 @@ A personal Claude Code plugin marketplace.
 Jira and Confluence skills for the Atlassian suite — search, create, update, and manage work items and pages.
 
 **Skills:**
-- `/spycner-tools:jira` — Search issues, create/update tickets, transition status, add comments, manage sprints
-- `/spycner-tools:confluence` — Search pages, read documentation, create/update pages, browse spaces
+- `/pgoell-claude-tools:jira` — Search issues, create/update tickets, transition status, add comments, manage sprints
+- `/pgoell-claude-tools:confluence` — Search pages, read documentation, create/update pages, browse spaces
 
 ### google-workspace
 
 Gmail and Calendar skills for Google Workspace — powered by the `gws` CLI.
 
 **Skills:**
-- `/spycner-tools:gmail` — Search, read, send, and manage Gmail messages, drafts, labels, and filters
-- `/spycner-tools:calendar` — View agenda, create and manage events, check availability, manage calendars
+- `/pgoell-claude-tools:gmail` — Search, read, send, and manage Gmail messages, drafts, labels, and filters
+- `/pgoell-claude-tools:calendar` — View agenda, create and manage events, check availability, manage calendars
 
 ### research
 
 Comprehensive web research with multi-perspective analysis, or optimized prompt generation for external AI tools.
 
 **Skills:**
-- `/spycner-tools:research` — Research intake, refinement, and routing. Orchestrates a multi-agent pipeline (planner, researcher, writer) with independent review gates for quality assurance, or generates optimized prompts for external AI tools (OpenAI, Gemini, Perplexity).
+- `/pgoell-claude-tools:research` — Research intake, refinement, and routing. Orchestrates a multi-agent pipeline (planner, researcher, writer) with independent review gates for quality assurance, or generates optimized prompts for external AI tools (OpenAI, Gemini, Perplexity).
 
 ## Installation
 
 ```
-/plugin marketplace add Spycner/spycner-tools
-/plugin install atlassian@spycner-tools
-/plugin install google-workspace@spycner-tools
-/plugin install research@spycner-tools
+/plugin marketplace add pgoell/pgoell-claude-tools
+/plugin install atlassian@pgoell-claude-tools
+/plugin install google-workspace@pgoell-claude-tools
+/plugin install research@pgoell-claude-tools
 ```
 
 ## Setup

--- a/tests/integration/test-gmail-integration.sh
+++ b/tests/integration/test-gmail-integration.sh
@@ -44,7 +44,7 @@ show_tools_used "$LOG_DIR/read.json"
 echo ""
 echo "Test 4: Send email to self"
 TIMESTAMP=$(date +%s)
-output=$(run_claude_logged "Use gws to send an email to me (my own address) with subject 'Integration test $TIMESTAMP' and body 'Automated test from spycner-tools'." "$LOG_DIR/send.json" 120)
+output=$(run_claude_logged "Use gws to send an email to me (my own address) with subject 'Integration test $TIMESTAMP' and body 'Automated test from pgoell-claude-tools'." "$LOG_DIR/send.json" 120)
 assert_not_contains "$output" "unauthorized|403|401" "Send without auth errors" || true
 show_tools_used "$LOG_DIR/send.json"
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo "=== spycner-tools Plugin Tests ==="
+echo "=== pgoell-claude-tools Plugin Tests ==="
 echo ""
 
 # Set plugin directory for all tests

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Helper functions for spycner-tools plugin tests
+# Helper functions for pgoell-claude-tools plugin tests
 # Follows superpowers test-helpers.sh pattern
 
 # macOS compatibility: use gtimeout if available, otherwise a bash fallback


### PR DESCRIPTION
## Summary
- Renamed all references from `spycner-tools` to `pgoell-claude-tools`
- Updated marketplace.json, CLAUDE.md, README.md, and test files

Reflects GitHub username change (Spycner → pgoell) and clearer project naming.