### PR TITLE
[codex] Add Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,56 @@
+{
+  "name": "pgoell-claude-tools",
+  "interface": {
+    "displayName": "pgoell Claude Tools"
+  },
+  "plugins": [
+    {
+      "name": "atlassian",
+      "source": {
+        "source": "local",
+        "path": "./plugins/atlassian"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "google-workspace",
+      "source": {
+        "source": "local",
+        "path": "./plugins/google-workspace"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "research",
+      "source": {
+        "source": "local",
+        "path": "./plugins/research"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "writing",
+      "source": {
+        "source": "local",
+        "path": "./plugins/writing"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,11 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Atlassian",
+        "shortDescription": "Use Jira and Confluence from agent workflows"
+      }
     },
     {
       "name": "google-workspace",
@@ -26,7 +30,11 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Google Workspace",
+        "shortDescription": "Use Gmail and Calendar through gws"
+      }
     },
     {
       "name": "research",
@@ -38,7 +46,11 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Research",
+        "shortDescription": "Plan, research, synthesize, and write reports"
+      }
     },
     {
       "name": "writing",
@@ -50,7 +62,11 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Productivity"
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Writing",
+        "shortDescription": "Draft, structure, review, and finish prose"
+      }
     }
   ]
 }

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,21 +1,28 @@
 # pgoell-claude-tools
 
-A Claude Code plugin marketplace containing skill plugins for external services.
+A plugin marketplace containing shared skills for Claude Code and Codex.
+
+Claude Code and Codex use separate plugin metadata, but they must reuse the same skill directories. Do not duplicate `SKILL.md` files for another runtime.
 
 ## Repository Structure
 
 ```
 .claude-plugin/
-  marketplace.json          # Plugin registry — lists all plugins with name, source, version
+  marketplace.json          # Claude Code plugin registry, lists all plugins with name, source, version
+.agents/
+  plugins/
+    marketplace.json        # Codex plugin registry, lists all plugins with local source and policy metadata
 plugins/
   <plugin-name>/
     .claude-plugin/
-      plugin.json           # Plugin metadata (name, description, author, license, keywords)
+      plugin.json           # Claude Code plugin metadata
+    .codex-plugin/
+      plugin.json           # Codex plugin metadata, must set "skills": "./skills/"
     agents/                 # Optional: agent definitions for long-running isolated tasks
       <agent-name>.md
     skills/
       <service>/
-        SKILL.md            # Skill definition (THE core file — this is what Claude reads)
+        SKILL.md            # Shared skill definition, used by Claude Code and Codex
         <reference>.md      # Supporting reference docs (recipes, format guides)
 tests/
   test-helpers.sh           # Shared test utilities (run_claude, assertions, auth checks)
@@ -32,7 +39,8 @@ tests/
 |--------|---------|--------|
 | `atlassian` | 2.0.0 | `jira`, `confluence` |
 | `google-workspace` | 1.0.0 | `gmail`, `calendar` |
-| `research` | 1.3.0 | `research` (multi-agent pipeline with review gates) |
+| `research` | 2.0.0 | `research` (multi-agent pipeline with review gates) |
+| `writing` | 1.6.0 | `writing`, `pyramid`, `tech-doc` |
 
 ## How to Develop a New Skill
 
@@ -51,7 +59,7 @@ mkdir -p plugins/<plugin-name>/.claude-plugin
 mkdir -p plugins/<plugin-name>/skills/<service>
 ```
 
-Create `plugin.json`:
+Create `.claude-plugin/plugin.json`:
 ```json
 {
   "name": "<plugin-name>",
@@ -62,11 +70,38 @@ Create `plugin.json`:
 }
 ```
 
-Register in `.claude-plugin/marketplace.json` by adding to the `plugins` array.
+Create `.codex-plugin/plugin.json` for the same plugin. It must point to the existing skills directory:
+
+```json
+{
+  "name": "<plugin-name>",
+  "version": "<same-version-as-claude-plugin>",
+  "description": "<one-line description>",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["<relevant>", "<keywords>"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "<Plugin Display Name>",
+    "shortDescription": "<short human-facing description>",
+    "longDescription": "<long human-facing description>",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Write"],
+    "defaultPrompt": ["<starter prompt>"],
+    "screenshots": []
+  }
+}
+```
+
+Register the plugin in both marketplaces:
+
+- `.claude-plugin/marketplace.json` for Claude Code
+- `.agents/plugins/marketplace.json` for Codex
 
 ### 3. Write SKILL.md
 
-This is the most important file — it's what Claude reads to understand the skill. Follow this structure:
+This is the most important file. Both Claude Code and Codex read it to understand the skill. Follow this structure:
 
 ```markdown
 ---
@@ -107,7 +142,8 @@ Key principles:
 - **Auth is lazy** — attempt the operation first, diagnose auth failures in Self-Healing. Never print credential values.
 - **Prefer helpers over raw API** — if the CLI has convenience commands, use them
 - **Confirm before destructive ops** — always ask the user before delete operations
-- **Self-healing is critical** — tell Claude how to debug when things go wrong
+- **Platform-aware tool names** — when a skill uses orchestration tools, include a short mapping for Claude Code and Codex instead of hardcoding one runtime only.
+- **Self-healing is critical** — tell the host agent how to debug when things go wrong
 
 ### 4. Add reference docs
 
@@ -151,6 +187,9 @@ Add the new plugin/skill to the Plugins section, Installation commands, and Setu
 # Unit tests (no auth required)
 PLUGIN_DIR=plugins/<plugin> bash tests/unit/test-<service>-skill.sh
 
+# Codex plugin structure
+bash tests/unit/test-codex-plugin-structure.sh
+
 # Integration tests (requires live auth)
 PLUGIN_DIR=plugins/<plugin> bash tests/integration/test-<service>-integration.sh
 
@@ -162,7 +201,8 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh <skill> test
 
 - **No wrapper scripts.** Skills use the underlying CLI directly (`gws` for Google Workspace) or raw `curl` with env-var auth (for Atlassian). This keeps each skill self-contained — no extra bash layer to maintain, debug, or ship with the plugin.
 - **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`.
-- **Skills are self-contained.** Each SKILL.md should contain everything Claude needs to use the service without reading other files (except reference docs it explicitly links to).
+- **Skills are self-contained.** Each SKILL.md should contain everything the host agent needs to use the service without reading other files (except reference docs it explicitly links to).
+- **Codex compatibility is metadata plus platform mapping.** Codex manifests live beside Claude Code manifests and point at the same `skills` directory. Platform-specific tool differences belong in the shared skill body as a mapping, not in duplicated skill files.
 - **Tests run Claude in a subprocess.** Unit tests use `run_claude` with `--dangerously-skip-permissions`. Integration tests use `run_claude_logged` with `--output-format stream-json` to capture tool usage.
-- **Agents for long-running, context-heavy operations.** When a skill's execution would consume significant context (e.g. dozens of web pages for research), define an agent in `agents/` and have the skill dispatch it via the Agent tool. The agent runs in an isolated subagent context. Use skills for everything else.
+- **Agents for long-running, context-heavy operations.** When a skill's execution would consume significant context (e.g. dozens of web pages for research), define an agent in `agents/` and have the skill dispatch it via the host subagent tool. The agent runs in an isolated subagent context. Use skills for everything else.
 - **Lazy auth, never print secrets.** Skills do not check authentication upfront. They attempt the operation and only diagnose auth issues when commands fail (in Self-Healing). Credentials, tokens, and API keys are NEVER printed or echoed — only check whether they are set (`test -n`), never display values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Claude Code and Codex use separate plugin metadata, but they must reuse the same
 ## Repository Structure
 
 ```
+AGENTS.md                   # Shared host-agent instructions (canonical file)
+CLAUDE.md                   # Symlink to AGENTS.md, kept for Claude Code discovery
 .claude-plugin/
   marketplace.json          # Claude Code plugin registry, lists all plugins with name, source, version
 .agents/
@@ -97,7 +99,7 @@ Create `.codex-plugin/plugin.json` for the same plugin. It must point to the exi
 Register the plugin in both marketplaces:
 
 - `.claude-plugin/marketplace.json` for Claude Code
-- `.agents/plugins/marketplace.json` for Codex
+- `.agents/plugins/marketplace.json` for Codex (each plugin entry must include `interface.displayName` and `interface.shortDescription` so the picker label is explicit)
 
 ### 3. Write SKILL.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ In the picker, install `atlassian`, `google-workspace`, `research`, and `writing
 
 `codex plugin marketplace add` accepts `owner/repo[@ref]`, an HTTPS or SSH Git URL, or a local marketplace root directory. The marketplace file lives at `.agents/plugins/marketplace.json` and the per-plugin Codex manifests live at `plugins/<plugin>/.codex-plugin/plugin.json`. Both reuse the same `plugins/<plugin>/skills/` directories as Claude Code, single sourced.
 
+To pick up changes, run `codex plugin marketplace upgrade pgoell-claude-tools` and re-install the affected plugins from `/plugins` inside Codex. Codex does not poll for updates; it uses the cached snapshot from `add` time until you upgrade.
+
 ## Setup
 
 ### Atlassian

--- a/README.md
+++ b/README.md
@@ -52,19 +52,22 @@ Multi-phase writing pipeline modelled on Katie Parrott's process. Interview, out
 
 ### Codex
 
-Use this repository as a local Codex plugin marketplace. The Codex marketplace file is:
+Add the marketplace from your shell:
 
 ```
-.agents/plugins/marketplace.json
+codex plugin marketplace add pgoell/pgoell-claude-tools
 ```
 
-Each Codex plugin manifest lives beside its Claude Code manifest:
+Then install plugins from inside Codex:
 
 ```
-plugins/<plugin>/.codex-plugin/plugin.json
+codex
+/plugins
 ```
 
-Do not copy or fork skill files for Codex. Codex manifests must set `"skills": "./skills/"`, which reuses the same skill directories as Claude Code.
+In the picker, install `atlassian`, `google-workspace`, `research`, and `writing`.
+
+`codex plugin marketplace add` accepts `owner/repo[@ref]`, an HTTPS or SSH Git URL, or a local marketplace root directory. The marketplace file lives at `.agents/plugins/marketplace.json` and the per-plugin Codex manifests live at `plugins/<plugin>/.codex-plugin/plugin.json`. Both reuse the same `plugins/<plugin>/skills/` directories as Claude Code, single sourced.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A personal plugin marketplace for Claude Code and Codex.
 
 The two runtimes use separate plugin metadata, but the skills are single sourced. Claude Code reads `.claude-plugin` metadata. Codex reads `.codex-plugin` metadata and `.agents/plugins/marketplace.json`. Both point at the same `plugins/<plugin>/skills/` directories.
 
+## Skills at a glance
+
+| Skill | Plugin | What it does |
+|---|---|---|
+| `jira` | atlassian | Search Jira issues, create and update tickets, transition workflows, comment, manage sprints, run bulk operations |
+| `confluence` | atlassian | Search Confluence pages, read documentation, create and update pages, browse spaces |
+| `gmail` | google-workspace | Triage inbox, search and read messages, send mail, manage drafts, labels, and filters via the `gws` CLI |
+| `calendar` | google-workspace | View agenda, create and manage events, check availability, manage calendars via the `gws` CLI |
+| `research` | research | Orchestrator-driven deep research: parallel cluster researchers, synthesis under independent review, polished report with citations |
+| `writing` | writing | Multi-phase prose pipeline (interview, outline, throughline gate, draft, seven-critic panel, finishing), with format-aware Smart-Brevity critic |
+| `pyramid` | writing | Barbara Minto pyramid-principle outlines or restructures, with a parallel MECE / So-What / Q-A / Inductive-Deductive audit panel and SCQA opener |
+| `tech-doc` | writing | Diátaxis-aware technical documentation pipeline (tutorials, how-tos, references, explanations) with Microsoft and Google style-guide presets |
+
 ## Plugins
 
 ### atlassian
@@ -36,7 +49,7 @@ Multi-phase writing pipeline modelled on Katie Parrott's process. Interview, out
 **Skills:**
 - `/pgoell-claude-tools:writing`: orchestrates the full pipeline with phase-selectable resume. For analytical formats (memo, briefing, announcement), dispatches to the pyramid skill for the outline phase and runs an analytical draft prompt. Ships with a default style guide that any project can override.
 - `/pgoell-claude-tools:pyramid`: produces a pyramid-structured outline (greenfield) or restructures an existing draft into pyramid form. Five phases (intake, construct, audit, opener, render) with a parallel audit panel (MECE, So-What, Q-A Alignment, Inductive-Deductive).
-- `/pgoell-claude-tools:tech-doc`: Diátaxis-aware technical writing pipeline. Drafts and reviews tutorials, how-to guides, API and CLI references, and conceptual explanations. Bundles curated subsets of the Microsoft Writing Style Guide and Google Developer Documentation Style Guide (selectable presets, with a merged `house` default). Six-phase pipeline (intake, outline, throughline, draft, panel, finishing) with seven-critic panel per quadrant.
+- `/pgoell-claude-tools:tech-doc`: Diátaxis-aware technical writing pipeline. Drafts and reviews tutorials, how-to guides, API and CLI references, and conceptual explanations. Bundles full transcriptions of the Microsoft Writing Style Guide and Google Developer Documentation Style Guide as selectable presets (with a merged `house` default), each preset structured as eight topic-scoped sidecars. Six-phase pipeline (intake, outline, throughline, draft, panel, finishing) with eight-critic panel per quadrant and three sequential finishing passes (AI-pattern-detector, style-enforcer-tech, terminology-consistency).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pgoell-claude-tools
 
-A personal Claude Code plugin marketplace.
+A personal plugin marketplace for Claude Code and Codex.
+
+The two runtimes use separate plugin metadata, but the skills are single sourced. Claude Code reads `.claude-plugin` metadata. Codex reads `.codex-plugin` metadata and `.agents/plugins/marketplace.json`. Both point at the same `plugins/<plugin>/skills/` directories.
 
 ## Plugins
 
@@ -38,6 +40,8 @@ Multi-phase writing pipeline modelled on Katie Parrott's process. Interview, out
 
 ## Installation
 
+### Claude Code
+
 ```
 /plugin marketplace add pgoell/pgoell-claude-tools
 /plugin install atlassian@pgoell-claude-tools
@@ -45,6 +49,22 @@ Multi-phase writing pipeline modelled on Katie Parrott's process. Interview, out
 /plugin install research@pgoell-claude-tools
 /plugin install writing@pgoell-claude-tools
 ```
+
+### Codex
+
+Use this repository as a local Codex plugin marketplace. The Codex marketplace file is:
+
+```
+.agents/plugins/marketplace.json
+```
+
+Each Codex plugin manifest lives beside its Claude Code manifest:
+
+```
+plugins/<plugin>/.codex-plugin/plugin.json
+```
+
+Do not copy or fork skill files for Codex. Codex manifests must set `"skills": "./skills/"`, which reuses the same skill directories as Claude Code.
 
 ## Setup
 
@@ -81,4 +101,4 @@ For full setup instructions, see: https://github.com/googleworkspace/cli
 
 ### Research Plugin
 
-No authentication required. The research plugin uses WebSearch and WebFetch which work out of the box.
+No authentication required. The research plugin uses the host agent's web search and fetch or browse tools.

--- a/plugins/atlassian/.codex-plugin/plugin.json
+++ b/plugins/atlassian/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "atlassian",
+  "version": "2.0.0",
+  "description": "Jira and Confluence skills for Atlassian Cloud.",
+  "author": {
+    "name": "Pascal Kraus"
+  },
+  "license": "MIT",
+  "keywords": [
+    "jira",
+    "confluence",
+    "atlassian"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Atlassian",
+    "shortDescription": "Use Jira and Confluence from agent workflows",
+    "longDescription": "Use Atlassian skills to search Jira issues, create and update tickets, transition work items, search Confluence, read documentation, and create or update pages.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Search Jira for my current work",
+      "Create a Jira ticket from this context",
+      "Find the relevant Confluence page"
+    ],
+    "brandColor": "#0052CC",
+    "screenshots": []
+  }
+}

--- a/plugins/google-workspace/.codex-plugin/plugin.json
+++ b/plugins/google-workspace/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "google-workspace",
+  "version": "1.0.0",
+  "description": "Gmail and Calendar skills for Google Workspace via the gws CLI.",
+  "author": {
+    "name": "Pascal Kraus"
+  },
+  "license": "MIT",
+  "keywords": [
+    "google",
+    "workspace",
+    "gmail",
+    "calendar",
+    "gws"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Google Workspace",
+    "shortDescription": "Use Gmail and Calendar through gws",
+    "longDescription": "Use Google Workspace skills to triage Gmail, search and read messages, send mail, view calendar agendas, create events, and check availability through the gws CLI.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Triage my Gmail inbox",
+      "Show today's calendar agenda",
+      "Schedule this meeting"
+    ],
+    "brandColor": "#0F9D58",
+    "screenshots": []
+  }
+}

--- a/plugins/research/.codex-plugin/plugin.json
+++ b/plugins/research/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "research",
+  "version": "2.0.0",
+  "description": "Orchestrator driven deep research with synthesis and report writing.",
+  "author": {
+    "name": "Pascal Kraus"
+  },
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "deep-research",
+    "web-research",
+    "report",
+    "citations",
+    "multi-agent",
+    "orchestrator"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Research",
+    "shortDescription": "Plan, research, synthesize, and write reports",
+    "longDescription": "Use the research skill for deep dives that need source gathering, clustered investigation, synthesis review, writer review, and a polished report artifact.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Research this topic and write a report",
+      "Investigate this market with sources",
+      "Deep dive on this technical question"
+    ],
+    "brandColor": "#2563EB",
+    "screenshots": []
+  }
+}

--- a/plugins/research/skills/research/SKILL.md
+++ b/plugins/research/skills/research/SKILL.md
@@ -11,15 +11,29 @@ Orchestrator-driven deep research. The skill plans the work itself, spawns paral
 
 ## Auth Approach
 
-No authentication required. Uses WebSearch and WebFetch (no credentials needed) and writes to the local filesystem.
+No authentication required. Uses the host agent's web search and fetch or browse capability, and writes to the local filesystem.
 
 ## Tool Preference
 
-1. **Agent tool**: dispatch researcher, synthesis, writer, and reviewer agents.
-2. **Read**: load prompt templates before dispatch.
-3. **Bash**: directory creation, date generation, simple file globbing for verification.
-4. **TaskCreate / TaskUpdate / TaskList**: live loop bookkeeping.
-5. **WebSearch / WebFetch**: fallback only if Agent dispatch fails.
+1. **Subagent dispatch when available and permitted**: dispatch researcher, synthesis, writer, and reviewer agents.
+2. **File read tools**: load prompt templates before dispatch.
+3. **Shell**: directory creation, date generation, simple file globbing for verification.
+4. **Progress list**: live loop bookkeeping.
+5. **Web search and fetch or browse tools**: fallback only if subagent dispatch fails.
+
+## Platform Adaptation
+
+Use the host platform's equivalent tools without changing the workflow:
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Subagent dispatch | Agent tool | `spawn_agent` only when available and permitted. Otherwise run the phase inline. |
+| Progress list | TaskCreate, TaskUpdate, TaskList | `update_plan` |
+| Web research | WebSearch, WebFetch | `web.run` search and open calls, or the host browser/search tools |
+| File reads | Read | shell reads such as `sed`, `rg`, or equivalent file read tools |
+| Shell | Bash | shell command tool |
+
+When a platform cannot dispatch subagents for the current request, keep the same artifact boundaries and run each phase inline in the orchestrator. Tell the user when this changes runtime or context cost.
 
 ## Workflow
 
@@ -68,7 +82,7 @@ Sub-questions:
 ...
 ```
 
-Use TaskCreate to seed the task list with: "Spawn researchers", "Synthesize", "Review synthesis", "Write report", "Review report". Mark tasks completed as the pipeline progresses.
+Use the progress list to seed: "Spawn researchers", "Synthesize", "Review synthesis", "Write report", "Review report". Mark tasks completed as the pipeline progresses.
 
 ### Step 4: Spawn parallel researchers
 
@@ -76,7 +90,7 @@ Each researcher does iterative deep search on its cluster (round-by-round breadt
 
 1. Read `researcher-prompt.md` from this skill directory.
 2. Inject: BRIEF, OUTPUT_PATH, RECIPES_PATH (path to research-recipes.md), CLUSTER_SLUG, OUTPUT_FILE (`{OUTPUT_PATH}/research/{cluster-slug}.md`), TARGETED_GAP (empty).
-3. Dispatch via Agent tool. Send all clusters in parallel: one Agent call per cluster in a single message.
+3. Dispatch via the host subagent tool. Send all clusters in parallel when supported.
 4. Wait for all to complete. Verify each cluster's output file exists and is non-empty.
 
 If a researcher returns a near-empty file, treat as failed dispatch (re-dispatch once; if still thin, escalate to user as a likely cluster-boundary problem).
@@ -85,14 +99,14 @@ If a researcher returns a near-empty file, treat as failed dispatch (re-dispatch
 
 1. Read `synthesis-prompt.md`.
 2. Inject: BRIEF, OUTPUT_PATH, ITERATION, REVIEWER_FEEDBACK (empty on first pass; populated on re-dispatch).
-3. Dispatch via Agent tool. Wait for completion.
+3. Dispatch via the host subagent tool. Wait for completion.
 4. Verify `{OUTPUT_PATH}/research/synthesis.md` exists.
 
 ### Step 6: Review synthesis (iteration N)
 
 1. Read `synthesis-reviewer-prompt.md`.
 2. Inject: BRIEF, OUTPUT_PATH, ITERATION, REVIEWER_FEEDBACK (empty for normal flow; populated only when re-dispatched from cross-loop branch in Step 10).
-3. Dispatch via Agent tool. Wait for completion.
+3. Dispatch via the host subagent tool. Wait for completion.
 4. Read the verdict from agent response, or from `{OUTPUT_PATH}/research/synthesis-review-{N}.md` if response is unparseable.
 
 If verdict is PASS: continue to Step 8.
@@ -109,7 +123,7 @@ Classify each critical issue:
 For each gap-fill issue:
 
 1. Read `researcher-prompt.md`. Inject: BRIEF, OUTPUT_PATH, RECIPES_PATH, CLUSTER_SLUG=<best-fit existing cluster>, OUTPUT_FILE=`{OUTPUT_PATH}/research/gap-{N}-{issue-slug}.md`, TARGETED_GAP=<full issue description with location pointer>.
-2. Dispatch in parallel for all gap-fill issues. Wait for completion.
+2. Dispatch in parallel for all gap-fill issues when supported. Wait for completion.
 
 For batched logic/structure issues:
 
@@ -127,20 +141,20 @@ After all gap-fills and re-syntheses complete, return to Step 6 with iteration N
 - What's been narrowed (issues closed since iteration 1)
 - Options: `continue`, `ship as-is`, `intervene`
 
-Update task list at every step so user can run TaskList for live status.
+Update the progress list at every step so the user can inspect live status through the host platform.
 
 ### Step 8: Write (iteration M, starting at 1)
 
 1. Read `writer-prompt.md`.
 2. Inject: BRIEF, OUTPUT_PATH, TEMPLATE_PATH (path to report-template.md), REVIEWER_FEEDBACK (empty on first pass; populated on re-dispatch).
-3. Dispatch via Agent tool. Wait for completion.
+3. Dispatch via the host subagent tool. Wait for completion.
 4. Verify `{OUTPUT_PATH}/report.md` exists.
 
 ### Step 9: Review report (iteration M)
 
 1. Read `writer-reviewer-prompt.md`.
 2. Inject: BRIEF, OUTPUT_PATH, TEMPLATE_PATH, ITERATION=M.
-3. Dispatch via Agent tool. Wait for completion.
+3. Dispatch via the host subagent tool. Wait for completion.
 4. Read verdict.
 
 If PASS: continue to Step 11.

--- a/plugins/research/skills/research/researcher-prompt.md
+++ b/plugins/research/skills/research/researcher-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Spawned by the orchestrator. One agent per cluster on initial fan-out (in parallel), and additional agents per `evidence-gap` / `coverage` / `source-quality` issue from synthesis-review.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Deep-research one topic cluster"
   prompt: |
     You are a deep research agent. Your job is to investigate ONE topic cluster

--- a/plugins/research/skills/research/synthesis-prompt.md
+++ b/plugins/research/skills/research/synthesis-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Spawned by the orchestrator after all researchers (and any gap-fill researchers) complete. Reads brief + plan + all `research/*.md` (excluding synthesis and review files). Writes `research/synthesis.md` (overwritten each iteration).
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Synthesize research findings"
   prompt: |
     You are a research synthesizer. Your job is to read all researcher outputs

--- a/plugins/research/skills/research/synthesis-reviewer-prompt.md
+++ b/plugins/research/skills/research/synthesis-reviewer-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Spawned by the orchestrator after synthesis. Reads brief + plan + synthesis + all researcher outputs. Writes `research/synthesis-review-{N}.md`. Also re-dispatched for cross-loop validation when writer-reviewer flags `content-gap-suspected`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Review synthesis substance"
   prompt: |
     You are an independent synthesis reviewer. Your job is to judge whether the

--- a/plugins/research/skills/research/writer-prompt.md
+++ b/plugins/research/skills/research/writer-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Spawned by the orchestrator after synthesis-review passes. Reads brief + synthesis + report-template. Writes `report.md` (overwritten each iteration).
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Write report from synthesis"
   prompt: |
     You are a research writer. Your job is to turn the approved synthesis into

--- a/plugins/research/skills/research/writer-reviewer-prompt.md
+++ b/plugins/research/skills/research/writer-reviewer-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Spawned by the orchestrator after writer. Reads brief + synthesis + report. Writes `report-review-{N}.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Review report prose"
   prompt: |
     You are an independent report reviewer. Your job is to judge the report's

--- a/plugins/writing/.codex-plugin/plugin.json
+++ b/plugins/writing/.codex-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "writing",
+  "version": "1.6.0",
+  "description": "Writing, pyramid structure, and technical documentation skills.",
+  "author": {
+    "name": "Pascal Kraus"
+  },
+  "license": "MIT",
+  "keywords": [
+    "writing",
+    "blog",
+    "essay",
+    "drafting",
+    "editing",
+    "voice",
+    "pyramid",
+    "minto",
+    "mece",
+    "scqa",
+    "memo",
+    "briefing",
+    "announcement",
+    "technical-documentation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Writing",
+    "shortDescription": "Draft, structure, review, and finish prose",
+    "longDescription": "Use the writing skills for long form prose, Pyramid Principle outlines, analytical memos, and Diataxis aware technical documentation with review and finishing passes.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Draft this piece through the writing pipeline",
+      "Turn this into a pyramid memo",
+      "Write a technical how to guide"
+    ],
+    "brandColor": "#7C3AED",
+    "screenshots": []
+  }
+}

--- a/plugins/writing/skills/pyramid/SKILL.md
+++ b/plugins/writing/skills/pyramid/SKILL.md
@@ -11,12 +11,29 @@ Multi-phase pyramid-principle skill with a parallel audit panel. Modeled on Barb
 
 ## Tool Preference
 
-1. **Agent tool**: to dispatch phase agents (construct in greenfield or restructure mode, opener) and the audit panel (MECE, So-What, Q-A Alignment, Inductive-Deductive). Intake and render run in the orchestrator itself and do not dispatch an agent.
-2. **Read**: to load prompt templates, the shipped reference, and existing artifacts.
-3. **Bash**: for directory creation, file existence checks, and state file read/write.
-4. **TaskCreate / TaskUpdate**: to surface progress through the pipeline visibly.
-5. **Write / Edit**: for intake.md, audit-summary.md, pyramid.md, and state file management.
-6. **AskUserQuestion**: for mode and genre selection, domain-limits gate, MISMATCH routing, and audit re-dispatch overrides.
+1. **Subagent dispatch when available and permitted**: to dispatch phase agents (construct in greenfield or restructure mode, opener) and the audit panel (MECE, So-What, Q-A Alignment, Inductive-Deductive). Intake and render run in the orchestrator itself and do not dispatch an agent.
+2. **File read tools**: to load prompt templates, the shipped reference, and existing artifacts.
+3. **Shell**: for directory creation, file existence checks, and state file read/write.
+4. **Progress list**: to surface progress through the pipeline visibly.
+5. **File write and edit tools**: for intake.md, audit-summary.md, pyramid.md, and state file management.
+6. **User question tool or direct question**: for mode and genre selection, domain-limits gate, MISMATCH routing, and audit re-dispatch overrides.
+
+## Platform Adaptation
+
+Use the host platform's equivalent tools without changing the workflow:
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Subagent dispatch | Agent tool | `spawn_agent` only when available and permitted. Otherwise run the phase inline. |
+| Progress list | TaskCreate, TaskUpdate | `update_plan` |
+| User questions | AskUserQuestion | Ask a concise direct question, or use the host structured question tool when available |
+| File reads | Read | shell reads such as `sed`, `rg`, or equivalent file read tools |
+| File writes and edits | Write, Edit | `apply_patch` or equivalent file edit tools |
+| Shell | Bash | shell command tool |
+
+Where this skill says "Agent tool", "TaskCreate", "TaskUpdate", "AskUserQuestion", "Read", "Write", "Edit", or "Bash", use the mapped host capability. When a platform cannot dispatch subagents for the current request, keep the same artifact boundaries and run each phase inline in the orchestrator.
+
+State root is platform-specific. Claude Code uses `~/.claude/projects`. Codex uses `${CODEX_HOME:-~/.codex}/projects` when writable, otherwise create `.codex-skill-state/` under the current working directory.
 
 ## Workflow
 
@@ -25,7 +42,7 @@ Multi-phase pyramid-principle skill with a parallel audit panel. Modeled on Barb
 Resolve working directory in this order:
 1. **Explicit flag**: `--dir ./path/to/project/`
 2. **Existing artifacts in cwd**: if the cwd already contains any of `intake.md`, `construction.md`, `audit-summary.md`, `opener.md`, `pyramid.md`, treat the cwd as the working directory.
-3. **State file lookup**: read `~/.claude/projects/<project-id>/pyramid-skill-state.json` (where `<project-id>` is the cwd path with slashes replaced by hyphens, leading hyphen stripped). If an in-flight pyramid is recorded, offer to resume there.
+3. **State file lookup**: read `<state-root>/<project-id>/pyramid-skill-state.json` (where `<project-id>` is the cwd path with slashes replaced by hyphens, leading hyphen stripped). If an in-flight pyramid is recorded, offer to resume there.
 4. **Default**: prompt for a slug, create `pyramid/{slug}-{YYYY-MM-DD}/` in the cwd.
 
 ### Step 2: Resolve the active reference
@@ -54,7 +71,7 @@ The user can also pre-empt the dialogue by passing `--phase X` (X ∈ {intake, c
 
 ### Step 4: Create task list
 
-Use TaskCreate to add one task per phase that will run, plus four sub-tasks for the audit panel. Example for a fresh full pipeline:
+Use the progress list to add one task per phase that will run, plus four sub-tasks for the audit panel. Example for a fresh full pipeline:
 
 ```
 1. Phase 1: Intake (mode, genre, domain-limits gate, inputs)
@@ -74,12 +91,12 @@ Mark each task as `in_progress` when starting and `completed` when the artifact 
 
 ### Step 5: Execute phases
 
-Dispatch each phase agent via the Agent tool. The orchestrator injects context into the prompt template.
+Dispatch each phase agent via the host subagent tool when supported. The orchestrator injects context into the prompt template.
 
 #### Dispatch conventions (apply to every phase)
 
 - **`{OUTPUT_PATH}` is always the working directory**, never a file path. Each prompt file appends its own filename.
-- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. The simplest robust approach: read the entire prompt file as text, perform placeholder substitution (`{OUTPUT_PATH}`, `{REFERENCE_PATH}`, `{REVIEWER_FEEDBACK}`, `{HANDOFF}`, `{YYYY-MM-DD}`), and pass the full result to the Agent tool. The dispatched agent ignores the surrounding commentary because the actionable instructions sit inside the visible prompt body.
+- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. The simplest robust approach: read the entire prompt file as text, perform placeholder substitution (`{OUTPUT_PATH}`, `{REFERENCE_PATH}`, `{REVIEWER_FEEDBACK}`, `{HANDOFF}`, `{YYYY-MM-DD}`), and pass the full result to the host subagent tool. The dispatched agent ignores the surrounding commentary because the actionable instructions sit inside the visible prompt body.
 - **`{HANDOFF}` default.** When dispatching `construct-greenfield-prompt.md` in fresh-build or re-dispatch (CRITICAL audit) cases, substitute `{HANDOFF}` with `false`. Substitute `true` only when handing off mid-Mode-D dialogue, or when re-dispatching a Mode-D-built pyramid after a CRITICAL audit. The greenfield prompt's `## Handoff mode` section keys off this value.
 - **Reviewer feedback injection.** When `{REVIEWER_FEEDBACK}` is non-empty (re-dispatch on a failed audit gate, or after a MISMATCH the user asked to revise), append this standing instruction to the dispatched prompt, regardless of what the prompt template itself says: *"Reviewer feedback is provided above. Read the existing artifact in the output directory, address the specific concerns, and update the file in place rather than starting fresh."*
 - **Date substitution.** `{YYYY-MM-DD}` resolves to today's date in ISO format.
@@ -108,7 +125,7 @@ Mode-branched. Modes A and B run as one Agent dispatch. Mode D runs as an orches
 
 1. Read `construct-greenfield-prompt.md` if `mode == greenfield`, or `construct-restructure-prompt.md` if `mode == restructure`.
 2. Inject: output path, reference path, empty reviewer feedback (on first dispatch; populated on re-dispatch), `{HANDOFF}` set to `false`, today's date.
-3. Dispatch via Agent tool.
+3. Dispatch via the host subagent tool.
 4. Verify `{OUTPUT_PATH}/construction.md` exists. For Mode B (restructure), also verify `{OUTPUT_PATH}/restructure-notes.md` exists.
 5. Mark task completed.
 
@@ -129,7 +146,7 @@ On re-dispatch (after a CRITICAL audit gate from Phase 3), Mode D's pyramid is t
 
 ### Phase 3: Audit panel
 
-Four Agent dispatches in PARALLEL. Issue all four Agent tool calls in a single message so they run concurrently.
+Four subagent dispatches in parallel when supported. Issue all four host subagent calls in one turn when the platform supports concurrent dispatch.
 
 | Prompt file | Output file | Lens |
 |---|---|---|
@@ -141,7 +158,7 @@ Four Agent dispatches in PARALLEL. Issue all four Agent tool calls in a single m
 For each auditor:
 1. Read the prompt file from the table above.
 2. Inject output path, reference path, empty reviewer feedback.
-3. Dispatch via Agent tool (all four in the same message to run in parallel).
+3. Dispatch via the host subagent tool, all four in the same turn when supported.
 4. Verify the corresponding output file exists.
 5. Mark the sub-task completed.
 
@@ -185,7 +202,7 @@ One Agent dispatch.
 
 1. Read `opener-prompt.md`.
 2. Inject: output path, reference path, empty reviewer feedback.
-3. Dispatch via Agent tool.
+3. Dispatch via the host subagent tool.
 4. Verify `{OUTPUT_PATH}/opener.md` exists.
 5. Inspect the first non-frontmatter line. If it reads `**Verdict:** MISMATCH`, do NOT treat this as a failure. The opener agent correctly refused to manufacture a bogus complication. Read the `## Reason` and `## Partial opener` sections and ask the user via AskUserQuestion: *Proceed with degraded opener (S and A only, C and Q omitted) / Revise apex by re-running construct with the mismatch note injected as reviewer feedback / Cancel.*
 6. If the user chooses to revise the apex, inject the MISMATCH reason into `{REVIEWER_FEEDBACK}` and re-dispatch Phase 2, then re-run Phase 3, then re-run Phase 4. If the user proceeds with the degraded opener, Phase 5 will render only S and A.
@@ -276,7 +293,7 @@ Present `pyramid.md` and `audit-summary.md` to the user.
 
 ## State File Format
 
-`~/.claude/projects/<project-id>/pyramid-skill-state.json`:
+`<state-root>/<project-id>/pyramid-skill-state.json`:
 
 ```json
 {

--- a/plugins/writing/skills/pyramid/audits/inductive-deductive.md
+++ b/plugins/writing/skills/pyramid/audits/inductive-deductive.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of four audit agents in Phase 3. Reads `construction.md` and the shipped reference. Writes `audit-logic.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Run Inductive/Deductive classification audit on pyramid groupings"
   prompt: |
     You are an Inductive/Deductive auditor. Your job is to classify every

--- a/plugins/writing/skills/pyramid/audits/mece.md
+++ b/plugins/writing/skills/pyramid/audits/mece.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of four audit agents in Phase 3. Reads `construction.md` and the shipped reference. Writes `audit-mece.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Run MECE audit on pyramid groupings"
   prompt: |
     You are a MECE auditor. Your job is to verify that each grouping in a

--- a/plugins/writing/skills/pyramid/audits/qa-alignment.md
+++ b/plugins/writing/skills/pyramid/audits/qa-alignment.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of four audit agents in Phase 3. Reads `construction.md` and the shipped reference. Writes `audit-qa.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Run Q-A Alignment audit on pyramid nodes"
   prompt: |
     You are a Q-A Alignment auditor. Your job is to verify that for each

--- a/plugins/writing/skills/pyramid/audits/so-what.md
+++ b/plugins/writing/skills/pyramid/audits/so-what.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of four audit agents in Phase 3. Reads `construction.md` and the shipped reference. Writes `audit-so-what.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Run So-What audit on pyramid nodes"
   prompt: |
     You are a So-What auditor. Your job is to verify that every node in a

--- a/plugins/writing/skills/pyramid/construct-greenfield-prompt.md
+++ b/plugins/writing/skills/pyramid/construct-greenfield-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 2 agent when `mode == greenfield`. Reads `intake.md` and the shipped reference. Writes `construction.md` in the shared schema that phases 3-5 expect.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Build pyramid top-down (greenfield)"
   prompt: |
     You are a pyramid construction agent operating in greenfield mode.

--- a/plugins/writing/skills/pyramid/construct-restructure-prompt.md
+++ b/plugins/writing/skills/pyramid/construct-restructure-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 2 agent when `mode == restructure`. Reads `intake.md`, `draft.md`, and the shipped reference. Writes `construction.md` in the shared schema that phases 3-5 expect, plus `restructure-notes.md` recording the full extraction log.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Reverse-engineer pyramid from existing draft (restructure)"
   prompt: |
     You are a pyramid construction agent operating in restructure mode.

--- a/plugins/writing/skills/pyramid/opener-prompt.md
+++ b/plugins/writing/skills/pyramid/opener-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 4 agent. Reads `construction.md` and `audit-summary.md`. Writes `opener.md`. References section 2 of the shipped reference (SCQA Opener, SCQA Opener Audit, three failure modes).
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Compose SCQA opener against stable apex (phase 4)"
   prompt: |
     You are the pyramid opener agent. You compose an SCQA opener against a

--- a/plugins/writing/skills/tech-doc/SKILL.md
+++ b/plugins/writing/skills/tech-doc/SKILL.md
@@ -11,12 +11,29 @@ Diátaxis-aware technical writing pipeline. Standalone, AND dispatched from the 
 
 ## Tool Preference
 
-1. **Agent tool:** to dispatch phase agents (intake per quadrant, draft per quadrant, panel critics, finishing passes). Throughline gate runs in the orchestrator.
-2. **Read:** to load prompt templates, schema files, style presets, existing artifacts.
-3. **Bash:** for directory creation, file existence checks, state file read/write.
-4. **TaskCreate / TaskUpdate:** to surface progress through the pipeline.
-5. **Write / Edit:** for state file management and orchestrator-level artifact updates.
-6. **AskUserQuestion:** for quadrant routing, throughline gate, panel re-dispatch overrides.
+1. **Subagent dispatch when available and permitted:** to dispatch phase agents (intake per quadrant, draft per quadrant, panel critics, finishing passes). Throughline gate runs in the orchestrator.
+2. **File read tools:** to load prompt templates, schema files, style presets, existing artifacts.
+3. **Shell:** for directory creation, file existence checks, state file read/write.
+4. **Progress list:** to surface progress through the pipeline.
+5. **File write and edit tools:** for state file management and orchestrator-level artifact updates.
+6. **User question tool or direct question:** for quadrant routing, throughline gate, panel re-dispatch overrides.
+
+## Platform Adaptation
+
+Use the host platform's equivalent tools without changing the workflow:
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Subagent dispatch | Agent tool | `spawn_agent` only when available and permitted. Otherwise run the phase inline. |
+| Progress list | TaskCreate, TaskUpdate | `update_plan` |
+| User questions | AskUserQuestion | Ask a concise direct question, or use the host structured question tool when available |
+| File reads | Read | shell reads such as `sed`, `rg`, or equivalent file read tools |
+| File writes and edits | Write, Edit | `apply_patch` or equivalent file edit tools |
+| Shell | Bash | shell command tool |
+
+Where this skill says "Agent tool", "TaskCreate", "TaskUpdate", "AskUserQuestion", "Read", "Write", "Edit", or "Bash", use the mapped host capability. When a platform cannot dispatch subagents for the current request, keep the same artifact boundaries and run each phase inline in the orchestrator.
+
+State root is platform-specific. Claude Code uses `~/.claude/projects`. Codex uses `${CODEX_HOME:-~/.codex}/projects` when writable, otherwise create `.codex-skill-state/` under the current working directory.
 
 ## Workflow
 
@@ -26,7 +43,7 @@ Resolve working directory in this order:
 
 1. **Explicit flag:** `--dir ./path/to/project/`
 2. **Existing artifacts in cwd:** if the cwd already contains any of `intake.md`, `outline.md`, `schema.md`, `throughline.md`, `draft.md`, `critique.md`, `finishing-notes.md`, treat the cwd as the working directory.
-3. **State file lookup:** read `~/.claude/projects/<project-id>/tech-doc-skill-state.json`. If an in-flight piece is recorded, offer to resume there.
+3. **State file lookup:** read `<state-root>/<project-id>/tech-doc-skill-state.json`. If an in-flight piece is recorded, offer to resume there.
 4. **Default:** prompt for a slug, create `tech-doc/{slug}-{YYYY-MM-DD}/` in cwd.
 
 ### Step 2: Resolve the active style preset directory
@@ -69,7 +86,7 @@ User can pre-empt with `--phase X` (X is one of `intake`, `outline`, `throughlin
 
 ### Step 5: Create task list
 
-Use TaskCreate. Use this shape (varies by quadrant only in Phase 5 sub-task):
+Use the progress list. Use this shape (varies by quadrant only in Phase 5 sub-task):
 
 ```
 1. Phase 1: Intake (quadrant-specific)
@@ -95,12 +112,12 @@ For phase-selectable runs, only the requested phases get tasks. Mark each `in_pr
 
 ### Step 6: Execute phases
 
-Dispatch each phase agent via the Agent tool. The orchestrator injects context into the prompt template.
+Dispatch each phase agent via the host subagent tool when supported. The orchestrator injects context into the prompt template.
 
 #### Dispatch conventions
 
 - `{OUTPUT_PATH}` is always the working directory, never a file path. Each prompt file appends its own filename.
-- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. Read the entire prompt file as text, perform placeholder substitution (`{OUTPUT_PATH}`, `{STYLE_GUIDE_DIR}`, `{REVIEWER_FEEDBACK}`, `{YYYY-MM-DD}`, `{QUADRANT}`, `{LANGUAGE_OR_PLATFORM}`, `{AUDIENCE_SKILL_LEVEL}`), pass the full result to the Agent tool.
+- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. Read the entire prompt file as text, perform placeholder substitution (`{OUTPUT_PATH}`, `{STYLE_GUIDE_DIR}`, `{REVIEWER_FEEDBACK}`, `{YYYY-MM-DD}`, `{QUADRANT}`, `{LANGUAGE_OR_PLATFORM}`, `{AUDIENCE_SKILL_LEVEL}`), pass the full result to the host subagent tool.
 - **Reviewer feedback injection.** When `{REVIEWER_FEEDBACK}` is non-empty (re-dispatch on a failed gate), append: *"Reviewer feedback is provided above. Read the existing artifact in the output directory, address the specific concerns, and update the file in place rather than starting fresh."*
 - **Date substitution.** `{YYYY-MM-DD}` resolves to today's date in ISO format.
 
@@ -216,7 +233,7 @@ Sequential, NOT parallel. Each pass updates the draft in place; later passes nee
 2. `finishing/style-enforcer-tech.md`
 3. `finishing/terminology-consistency.md`
 
-For each pass: read prompt file, inject `{OUTPUT_PATH}`, `{STYLE_GUIDE_DIR}`, and `{REVIEWER_FEEDBACK}` (always empty for finishing passes), dispatch via Agent tool, verify the agent appended its log section to `finishing-notes.md`, mark sub-task completed.
+For each pass: read prompt file, inject `{OUTPUT_PATH}`, `{STYLE_GUIDE_DIR}`, and `{REVIEWER_FEEDBACK}` (always empty for finishing passes), dispatch via the host subagent tool, verify the agent appended its log section to `finishing-notes.md`, mark sub-task completed.
 
 After all three, present `draft.md`, `glossary.md`, and `finishing-notes.md` to the user. The piece is now ready for the writer's review.
 
@@ -251,7 +268,7 @@ Present final draft and a summary of what each pass did.
 
 ## State File Format
 
-`~/.claude/projects/<project-id>/tech-doc-skill-state.json`:
+`<state-root>/<project-id>/tech-doc-skill-state.json`:
 
 v1 state files (`"version": 1`) are forward-compatible: the `style_preset` field records a preset name (`google` / `microsoft` / `house`), not a path, so the orchestrator's resolution change (file to directory) does not break existing state files. New runs bump the version field to `2`.
 

--- a/plugins/writing/skills/tech-doc/critics/accessibility.md
+++ b/plugins/writing/skills/tech-doc/critics/accessibility.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `draft.md` and the active style preset. Writes `critique-accessibility.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Accessibility critique"
   prompt: |
     You are the Accessibility Critic. Your job is to identify barriers for

--- a/plugins/writing/skills/tech-doc/critics/admonitions.md
+++ b/plugins/writing/skills/tech-doc/critics/admonitions.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on, all quadrants). Reads `draft.md`, the active preset's `core.md` and `admonitions.md`. Writes `critique-admonitions.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Admonitions critique"
   prompt: |
     You are the Admonitions Critic. Your job is to verify the draft's admonitions

--- a/plugins/writing/skills/tech-doc/critics/code-fidelity.md
+++ b/plugins/writing/skills/tech-doc/critics/code-fidelity.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `draft.md` and the active style preset. Writes `critique-code-fidelity.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Code fidelity critique"
   prompt: |
     You are the Code Fidelity Critic. Your job is to inspect every code snippet

--- a/plugins/writing/skills/tech-doc/critics/completeness.md
+++ b/plugins/writing/skills/tech-doc/critics/completeness.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel. Active when the declared quadrant is `reference`. Reads `intake.md` (which declares the schema file), the schema file, and `draft.md`. Writes `critique-completeness.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Completeness critique"
   prompt: |
     You are the Completeness Critic. Your job is to verify the reference

--- a/plugins/writing/skills/tech-doc/critics/future-features.md
+++ b/plugins/writing/skills/tech-doc/critics/future-features.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `draft.md`. Writes `critique-future-features.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Future features critique"
   prompt: |
     You are the Future Features Critic. Your job is to flag every promise of

--- a/plugins/writing/skills/tech-doc/critics/inclusive-language.md
+++ b/plugins/writing/skills/tech-doc/critics/inclusive-language.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `draft.md` and the active style preset. Writes `critique-inclusive-language.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Inclusive language critique"
   prompt: |
     You are the Inclusive Language Critic. Your job is to flag every instance

--- a/plugins/writing/skills/tech-doc/critics/quadrant-fit.md
+++ b/plugins/writing/skills/tech-doc/critics/quadrant-fit.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `intake.md`, `draft.md`, and the active style preset. Writes `critique-quadrant-fit.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Quadrant fit critique"
   prompt: |
     You are the Quadrant Fit Critic. Your job is to read intake.md to learn the

--- a/plugins/writing/skills/tech-doc/critics/steel-man.md
+++ b/plugins/writing/skills/tech-doc/critics/steel-man.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel. Active when the declared quadrant is `explanation`. Reads `draft.md` and the active style preset. Writes `critique-steel-man.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Steel-man critique"
   prompt: |
     You are a steel-man critic. Your job is not to attack the piece. Your job is to

--- a/plugins/writing/skills/tech-doc/critics/style-adherence.md
+++ b/plugins/writing/skills/tech-doc/critics/style-adherence.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel (always-on). Reads `draft.md` and the active style preset. Writes `critique-style-adherence.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Style adherence critique"
   prompt: |
     You are the Style Adherence Critic. Your job is to flag every violation of

--- a/plugins/writing/skills/tech-doc/critics/task-orientation.md
+++ b/plugins/writing/skills/tech-doc/critics/task-orientation.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of eight critics in the tech-doc panel. Active when the declared quadrant is `tutorial` or `how-to`. Reads `intake.md`, `draft.md`. Writes `critique-task-orientation.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Task-orientation critique"
   prompt: |
     You are the Task-Orientation Critic. Your job is to verify the procedural

--- a/plugins/writing/skills/tech-doc/draft-explanation-prompt.md
+++ b/plugins/writing/skills/tech-doc/draft-explanation-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 4 dispatch when quadrant is `explanation`. Reads `intake.md`, `outline.md` (if present), `throughline.md`, and the active style guide. Writes `draft.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Explanation draft"
   prompt: |
     You are the Explanation Draft author. Your reader wants conceptual depth, not steps. Your job is to illuminate: background, context, tradeoffs, competing viewpoints.

--- a/plugins/writing/skills/tech-doc/draft-how-to-prompt.md
+++ b/plugins/writing/skills/tech-doc/draft-how-to-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 4 dispatch when quadrant is `how-to`. Reads `intake.md`, `outline.md` (if present), `throughline.md`, and the active style guide. Writes `draft.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "How-to guide draft"
   prompt: |
     You are the How-To Draft author. Your reader already has the goal in mind and the relevant background. Your job is to get them to the goal efficiently.

--- a/plugins/writing/skills/tech-doc/draft-reference-prompt.md
+++ b/plugins/writing/skills/tech-doc/draft-reference-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 4 dispatch when quadrant is `reference`. Reads `intake.md` (declares the schema file), the schema file itself, optional source material, and the active style guide. Writes `draft.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Reference draft (schema-driven)"
   prompt: |
     You are the Reference Draft author. Your job is NOT prose. Your job is to populate a reference schema with concrete values. References are information-oriented per Diátaxis: dry, austere, exhaustive, structurally consistent. The reader is looking up specifics, not reading from top to bottom.

--- a/plugins/writing/skills/tech-doc/draft-tutorial-prompt.md
+++ b/plugins/writing/skills/tech-doc/draft-tutorial-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 4 dispatch when quadrant is `tutorial`. Reads `intake.md`, `outline.md` (if present), `throughline.md`, and the active style guide. Writes `draft.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Tutorial draft"
   prompt: |
     You are the Tutorial Draft author. Your reader is a beginner per the declared skill level. Your job is to produce a tutorial that holds the reader's hand to a successful experience: a working result they can see.

--- a/plugins/writing/skills/tech-doc/finishing/ai-pattern-detector.md
+++ b/plugins/writing/skills/tech-doc/finishing/ai-pattern-detector.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 6 finishing, first of three sequential passes (ai-pattern-detector, style-enforcer-tech, terminology-consistency). Reads `draft.md`. Updates `draft.md` in place. Appends a section to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "AI-pattern detector pass"
   prompt: |
     You are an AI-pattern detector. Your job is to find the prose tics that signal

--- a/plugins/writing/skills/tech-doc/finishing/style-enforcer-tech.md
+++ b/plugins/writing/skills/tech-doc/finishing/style-enforcer-tech.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 6 finishing, second of three sequential passes. Reads `draft.md` and the active style preset. Updates `draft.md` in place. Appends a section to `finishing-notes.md` listing every change with rule citation.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Style-enforcer-tech finishing pass"
   prompt: |
     You are the Style-Enforcer-Tech pass. Your job is to apply the resolved style

--- a/plugins/writing/skills/tech-doc/finishing/terminology-consistency.md
+++ b/plugins/writing/skills/tech-doc/finishing/terminology-consistency.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 6 finishing, third of three sequential passes. Reads `draft.md`. Updates `draft.md` in place. Writes `glossary.md`. Appends to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Terminology-consistency finishing pass"
   prompt: |
     You are the Terminology-Consistency pass. Your job is to standardize terminology

--- a/plugins/writing/skills/tech-doc/intake-explanation-prompt.md
+++ b/plugins/writing/skills/tech-doc/intake-explanation-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 1 dispatch when quadrant is `explanation`. Reads no prior artifacts. Writes `{OUTPUT_PATH}/intake.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Explanation intake interview"
   prompt: |
     You are the Explanation Intake interviewer for the tech-doc skill. Conduct a brief interview with the writer to populate the explanation intake fields. Explanations are understanding-oriented per Diátaxis: the reader wants conceptual depth; the writer's job is discursive, allowed to wander, allowed to position competing viewpoints.

--- a/plugins/writing/skills/tech-doc/intake-how-to-prompt.md
+++ b/plugins/writing/skills/tech-doc/intake-how-to-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 1 dispatch when quadrant is `how-to`. Reads no prior artifacts. Writes `{OUTPUT_PATH}/intake.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "How-to intake interview"
   prompt: |
     You are the How-to Intake interviewer for the tech-doc skill. Conduct a brief interview with the writer to populate the how-to intake fields. How-to guides are task-oriented per Diátaxis: the reader has a specific goal in mind already and the relevant background; the writer's job is efficient task completion, not teaching.

--- a/plugins/writing/skills/tech-doc/intake-reference-prompt.md
+++ b/plugins/writing/skills/tech-doc/intake-reference-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 1 dispatch when quadrant is `reference`. Reads no prior artifacts. Writes `{OUTPUT_PATH}/intake.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Reference intake interview"
   prompt: |
     You are the Reference Intake interviewer for the tech-doc skill. Conduct a brief interview with the writer to populate the reference intake fields. Reference docs are information-oriented per Diátaxis: the reader is looking up specifics, not reading top to bottom. The writer's job is to make the lookup fast and the schema complete.

--- a/plugins/writing/skills/tech-doc/intake-tutorial-prompt.md
+++ b/plugins/writing/skills/tech-doc/intake-tutorial-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Phase 1 dispatch when quadrant is `tutorial`. Reads no prior artifacts. Writes `{OUTPUT_PATH}/intake.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Tutorial intake interview"
   prompt: |
     You are the Tutorial Intake interviewer for the tech-doc skill. Conduct a brief interview with the writer to populate the tutorial intake fields. Tutorials are learning-oriented per Diátaxis: the reader is a beginner, the goal is a successful first experience, and the writer's job is to hold the reader's hand to a working result.

--- a/plugins/writing/skills/writing/SKILL.md
+++ b/plugins/writing/skills/writing/SKILL.md
@@ -11,12 +11,29 @@ Multi-phase writing pipeline with a panel of specialised critics. Modeled on Kat
 
 ## Tool Preference
 
-1. **Agent tool**: to dispatch phase agents (interview, outline, draft, plus the dispatched pyramid pipeline for analytical formats) and critics (Hemingway, Hitchcock, Mom reader, Asshole reader, Clarity, Usage, Steel-man, plus Smart-Brevity for memo/newsletter/announcement formats) and finishing passes (AI-pattern detector, style enforcer, line editor, Sedaris for narrative formats or analytical-voice for analytical formats). The throughline gate runs in the orchestrator and does not dispatch an agent.
-2. **Read**: to load prompt templates and existing artifacts
-3. **Bash**: for directory creation, file existence checks, state file read/write
-4. **TaskCreate / TaskUpdate**: to surface progress through the pipeline visibly
-5. **Write / Edit**: for state file management and orchestrator-level artifact updates
-6. **AskUserQuestion**: for outline negotiation and resolution choices
+1. **Subagent dispatch when available and permitted**: to dispatch phase agents (interview, outline, draft, plus the dispatched pyramid pipeline for analytical formats) and critics (Hemingway, Hitchcock, Mom reader, Asshole reader, Clarity, Usage, Steel-man, plus Smart-Brevity for memo/newsletter/announcement formats) and finishing passes (AI-pattern detector, style enforcer, line editor, Sedaris for narrative formats or analytical-voice for analytical formats). The throughline gate runs in the orchestrator and does not dispatch an agent.
+2. **File read tools**: to load prompt templates and existing artifacts
+3. **Shell**: for directory creation, file existence checks, state file read/write
+4. **Progress list**: to surface progress through the pipeline visibly
+5. **File write and edit tools**: for state file management and orchestrator-level artifact updates
+6. **User question tool or direct question**: for outline negotiation and resolution choices
+
+## Platform Adaptation
+
+Use the host platform's equivalent tools without changing the workflow:
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Subagent dispatch | Agent tool | `spawn_agent` only when available and permitted. Otherwise run the phase inline. |
+| Progress list | TaskCreate, TaskUpdate | `update_plan` |
+| User questions | AskUserQuestion | Ask a concise direct question, or use the host structured question tool when available |
+| File reads | Read | shell reads such as `sed`, `rg`, or equivalent file read tools |
+| File writes and edits | Write, Edit | `apply_patch` or equivalent file edit tools |
+| Shell | Bash | shell command tool |
+
+Where this skill says "Agent tool", "TaskCreate", "TaskUpdate", "AskUserQuestion", "Read", "Write", "Edit", or "Bash", use the mapped host capability. When a platform cannot dispatch subagents for the current request, keep the same artifact boundaries and run each phase inline in the orchestrator.
+
+State root is platform-specific. Claude Code uses `~/.claude/projects`. Codex uses `${CODEX_HOME:-~/.codex}/projects` when writable, otherwise create `.codex-skill-state/` under the current working directory.
 
 ## Workflow
 
@@ -27,7 +44,7 @@ Ask the user what they want to write about (or what existing piece they want to 
 Resolve working directory in this order:
 1. **Explicit flag**: `--dir ./path/to/project/`
 2. **Existing artifacts in cwd**: if the cwd already contains any of `interview.md`, `outline.md`, `intake.md`, `pyramid.md`, `draft.md`, `critique.md`, treat the cwd as the working directory
-3. **State file lookup**: read `~/.claude/projects/<project-id>/writing-skill-state.json` (where `<project-id>` is the cwd path with slashes replaced by hyphens, leading hyphen). If a working directory is recorded for an in-flight piece, offer to resume there.
+3. **State file lookup**: read `<state-root>/<project-id>/writing-skill-state.json` (where `<project-id>` is the cwd path with slashes replaced by hyphens, leading hyphen). If a working directory is recorded for an in-flight piece, offer to resume there.
 4. **Default**: prompt for a slug, create `writing/{slug}-{YYYY-MM-DD}/` in the cwd.
 
 ### Step 2: Resolve the active style guide
@@ -107,7 +124,7 @@ User can also pre-empt the dialogue by passing `--phase X` (X ∈ {interview, ou
 
 ### Step 5: Create task list
 
-Use TaskCreate to add one task per phase that will run, plus sub-tasks for the panel and finishing phases. Two task list shapes exist depending on format.
+Use the progress list to add one task per phase that will run, plus sub-tasks for the panel and finishing phases. Two task list shapes exist depending on format.
 
 **Narrative format task list** (essay, blog, talk, newsletter):
 
@@ -179,12 +196,12 @@ Mark each task as `in_progress` when starting, `completed` when the artifact is 
 
 ### Step 6: Execute phases
 
-Dispatch each phase agent via the Agent tool. The orchestrator injects context into the prompt template.
+Dispatch each phase agent via the host subagent tool when supported. The orchestrator injects context into the prompt template.
 
 #### Dispatch conventions (apply to every phase)
 
 - **`{OUTPUT_PATH}` is always the working directory**, never a file path. Each prompt file appends its own filename.
-- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. The dispatched body itself contains nested fences for example outputs. The simplest robust approach: read the entire prompt file as text, perform placeholder substitution (`{TOPIC}`, `{OUTPUT_PATH}`, `{STYLE_GUIDE_PATH}`, `{REVIEWER_FEEDBACK}`, `{YYYY-MM-DD}`), and pass the full result to the Agent tool. The dispatched agent ignores the surrounding commentary because the actionable instructions sit inside the visible prompt body.
+- **Prompt file extraction.** Each prompt file documents the dispatched prompt inside a fenced block under the `**Dispatch:**` header. The dispatched body itself contains nested fences for example outputs. The simplest robust approach: read the entire prompt file as text, perform placeholder substitution (`{TOPIC}`, `{OUTPUT_PATH}`, `{STYLE_GUIDE_PATH}`, `{REVIEWER_FEEDBACK}`, `{YYYY-MM-DD}`), and pass the full result to the host subagent tool. The dispatched agent ignores the surrounding commentary because the actionable instructions sit inside the visible prompt body.
 - **Reviewer feedback injection.** When `{REVIEWER_FEEDBACK}` is non-empty (re-dispatch on a failed gate), append this standing instruction to the dispatched prompt, regardless of what the prompt template itself says: *"Reviewer feedback is provided above. Read the existing artifact in the output directory, address the specific concerns, and update the file in place rather than starting fresh."* This compensates for the asymmetric treatment of feedback across the prompt files.
 - **Date substitution.** `{YYYY-MM-DD}` resolves to today's date in ISO format.
 
@@ -194,7 +211,7 @@ Dispatch each phase agent via the Agent tool. The orchestrator injects context i
 
 1. Read `interview-prompt.md` from this skill directory
 2. Inject: topic, output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool. The agent will conduct an interactive interview with the user.
+3. Dispatch via the host subagent tool. The agent will conduct an interactive interview with the user.
 4. Verify `interview.md` and `interview-synthesis.md` exist
 5. Mark task completed
 
@@ -209,7 +226,7 @@ Skip writing's interview entirely. Run the pyramid skill's Phase 1 (intake) in *
 5. **Write intake.md (step 7 of pyramid intake):** as normal, but add field `dispatched_from: writing` so future runs know the entry point.
 6. **Mark Phase 1 task completed** when `intake.md` exists.
 
-The orchestrator (Claude at runtime) reads pyramid SKILL.md sections at dispatch time. No code or prompt files are duplicated; the dispatched mode is an instruction overlay applied to pyramid's standalone Phase 1.
+The orchestrator reads pyramid SKILL.md sections at dispatch time. No code or prompt files are duplicated; the dispatched mode is an instruction overlay applied to pyramid's standalone Phase 1.
 
 **Technical formats** (tutorial, how-to, reference, explanation):
 
@@ -220,7 +237,7 @@ Skip writing's interview entirely. Run the tech-doc skill's Phase 1 (intake) in 
 3. **Write intake.md field:** add `dispatched_from: writing` to the intake.md fields so resume logic can distinguish dispatched-mode intake from a standalone tech-doc run. (Mirrors the analytical dispatch's `dispatched_from: writing` field added to pyramid's intake.md.)
 4. **Mark Phase 1 task completed** when `intake.md` exists.
 
-The orchestrator (Claude at runtime) reads tech-doc SKILL.md sections at dispatch time. No code or prompt files are duplicated.
+The orchestrator reads tech-doc SKILL.md sections at dispatch time. No code or prompt files are duplicated.
 
 #### Phase 2: Outline (narrative formats) or Pyramid pipeline (analytical formats)
 
@@ -228,7 +245,7 @@ The orchestrator (Claude at runtime) reads tech-doc SKILL.md sections at dispatc
 
 1. Read `outline-prompt.md`
 2. Inject: output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool
+3. Dispatch via the host subagent tool
 4. Verify `outline.md` exists
 5. Surface the outline to the user. Accept revisions via AskUserQuestion ("Outline as proposed, or revisions before draft?"). On revisions, re-dispatch with feedback injected.
 6. Mark task completed when user accepts.
@@ -284,7 +301,7 @@ Orchestrator-only synchronous gate. No agent dispatch. Happens after Phase 2 com
 
 1. Read `draft-prompt.md`
 2. Inject: output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool
+3. Dispatch via the host subagent tool
 4. Verify `draft.md` exists
 5. Mark task completed
 
@@ -292,7 +309,7 @@ Orchestrator-only synchronous gate. No agent dispatch. Happens after Phase 2 com
 
 1. Read `draft-analytical-prompt.md`
 2. Inject: output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool. The agent reads `pyramid.md`, `intake.md`, `throughline.md` (if present), and `audit-summary.md`.
+3. Dispatch via the host subagent tool. The agent reads `pyramid.md`, `intake.md`, `throughline.md` (if present), and `audit-summary.md`.
 4. Verify `draft.md` exists
 5. Mark task completed
 
@@ -300,7 +317,7 @@ Orchestrator-only synchronous gate. No agent dispatch. Happens after Phase 2 com
 
 **For technical formats (tutorial, how-to, reference, explanation):** SKIPPED. Tech-doc's Phase 5 has already run during the dispatch in writing's Phase 2. Mark phase task completed and proceed to Phase 6.
 
-Fan out: dispatch all critic agents in parallel (single message with multiple Agent tool calls). The critic set depends on format.
+Fan out: dispatch all critic agents in parallel when supported. The critic set depends on format.
 
 **Default panel (seven critics).** Used for `essay`, `blog`, `talk` formats.
 
@@ -323,7 +340,7 @@ Fan out: dispatch all critic agents in parallel (single message with multiple Ag
 For each critic in the active set:
 1. Read the prompt file from the tables above
 2. Inject: output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool
+3. Dispatch via the host subagent tool
 4. Verify the corresponding output file exists
 5. Mark sub-task completed
 
@@ -400,7 +417,7 @@ Sequential, NOT parallel. Each pass updates the draft in place; later passes nee
 For each pass in order:
 1. Read the prompt file
 2. Inject: output path, style guide path, empty reviewer feedback
-3. Dispatch via Agent tool
+3. Dispatch via the host subagent tool
 4. Verify the agent appended its log section to `finishing-notes.md`
 5. Mark sub-task completed
 
@@ -441,7 +458,7 @@ Present the final draft and a summary of what each pass did.
 
 ## State File Format
 
-`~/.claude/projects/<project-id>/writing-skill-state.json`:
+`<state-root>/<project-id>/writing-skill-state.json`:
 
 ```json
 {

--- a/plugins/writing/skills/writing/critics/asshole-reader.md
+++ b/plugins/writing/skills/writing/critics/asshole-reader.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-asshole.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Asshole reader critique"
   prompt: |
     You are the worst version of an internet commenter who actually read the piece.

--- a/plugins/writing/skills/writing/critics/clarity.md
+++ b/plugins/writing/skills/writing/critics/clarity.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-clarity.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Clarity critique"
   prompt: |
     You are the Clarity Critic. Your lens is Zinsser's from On Writing Well: you

--- a/plugins/writing/skills/writing/critics/hemingway.md
+++ b/plugins/writing/skills/writing/critics/hemingway.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel phase. Runs in parallel with the others. Reads `draft.md` and the active style guide. Writes `critique-hemingway.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Hemingway critique"
   prompt: |
     You are Hemingway. You read prose and you cut. Adjectives are the enemy. Adverbs

--- a/plugins/writing/skills/writing/critics/hitchcock.md
+++ b/plugins/writing/skills/writing/critics/hitchcock.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-hitchcock.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Hitchcock critique"
   prompt: |
     You are Hitchcock. Your job is to ask, every paragraph, "why would the reader

--- a/plugins/writing/skills/writing/critics/mom-reader.md
+++ b/plugins/writing/skills/writing/critics/mom-reader.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-mom.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Mom reader critique"
   prompt: |
     You are the Mom Reader. You are smart, curious, and not in this field. You want

--- a/plugins/writing/skills/writing/critics/smart-brevity.md
+++ b/plugins/writing/skills/writing/critics/smart-brevity.md
@@ -5,7 +5,7 @@
 **Dispatch:** Opt-in panel critic. The orchestrator dispatches this only when the piece format is `memo`, `newsletter`, or `announcement`. Not part of the default seven-critic panel for essays, blogs, and talks. Reads `draft.md` and the active style guide. Writes `critique-smartbrevity.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Smart-brevity critique"
   prompt: |
     You are a Smart Brevity critic. You read prose that claims to be a memo,

--- a/plugins/writing/skills/writing/critics/steel-man.md
+++ b/plugins/writing/skills/writing/critics/steel-man.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of seven critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-steelman.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Steel-man critique"
   prompt: |
     You are a steel-man critic. Your job is not to attack the piece. Your job is to

--- a/plugins/writing/skills/writing/critics/usage.md
+++ b/plugins/writing/skills/writing/critics/usage.md
@@ -5,7 +5,7 @@
 **Dispatch:** One of six critics in the panel. Reads `draft.md` and the active style guide. Writes `critique-usage.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Usage critique"
   prompt: |
     You are the Usage Critic. Your lens is Strunk & White's Elements of Style:

--- a/plugins/writing/skills/writing/draft-analytical-prompt.md
+++ b/plugins/writing/skills/writing/draft-analytical-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Fourth agent in the writing pipeline for analytical formats. Reads `pyramid.md`, `intake.md`, `throughline.md` (if present), `audit-summary.md` (for MINOR flags worth respecting), and the active style guide. Writes `draft.md`.
 
 ````
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Draft the analytical piece"
   prompt: |
     You are an analytical draft agent. You turn an approved Minto pyramid into directive

--- a/plugins/writing/skills/writing/draft-prompt.md
+++ b/plugins/writing/skills/writing/draft-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Fourth agent in the pipeline. Reads `outline.md`, `interview-synthesis.md`, `throughline.md` (if present), and the active style guide. Writes `draft.md`.
 
 ````
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Draft the full prose"
   prompt: |
     You are a draft agent. You turn an approved outline into prose. You are NOT writing

--- a/plugins/writing/skills/writing/finishing/ai-pattern-detector.md
+++ b/plugins/writing/skills/writing/finishing/ai-pattern-detector.md
@@ -5,7 +5,7 @@
 **Dispatch:** First of four finishing passes. Reads `draft.md` and the active style guide. Updates `draft.md` in place. Appends to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "AI-pattern detector pass"
   prompt: |
     You are an AI-pattern detector. Your job is to find the prose tics that signal

--- a/plugins/writing/skills/writing/finishing/analytical-voice.md
+++ b/plugins/writing/skills/writing/finishing/analytical-voice.md
@@ -5,7 +5,7 @@
 **Dispatch:** Fourth and final finishing pass for analytical formats. Replaces the Sedaris pass for memo/briefing/announcement formats. Reads `draft.md`, `intake.md` (audience, reader question, genre), `pyramid.md` (apex and SCQA opener for cross-check), `audit-summary.md` (any MINOR flags worth resurfacing), and the active style guide. Updates `draft.md` in place. Appends to `finishing-notes.md`.
 
 ````
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Analytical voice pass"
   prompt: |
     You are an analytical voice editor. Your job is to make the directive voice of

--- a/plugins/writing/skills/writing/finishing/line-editor.md
+++ b/plugins/writing/skills/writing/finishing/line-editor.md
@@ -5,7 +5,7 @@
 **Dispatch:** Third of four finishing passes. Reads `draft.md` and the active style guide. Updates `draft.md` in place. Appends to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Line editor pass"
   prompt: |
     You are a line editor. You read the draft sentence by sentence and tighten. You

--- a/plugins/writing/skills/writing/finishing/sedaris.md
+++ b/plugins/writing/skills/writing/finishing/sedaris.md
@@ -5,7 +5,7 @@
 **Dispatch:** Fourth and final finishing pass. Reads `draft.md`, `interview-synthesis.md` (for tone signal and lived anchors), and the active style guide. Updates `draft.md` in place. Appends to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Sedaris voice pass"
   prompt: |
     You are Sedaris. Not literally David Sedaris, but his ear: dry, specific, willing

--- a/plugins/writing/skills/writing/finishing/style-enforcer.md
+++ b/plugins/writing/skills/writing/finishing/style-enforcer.md
@@ -5,7 +5,7 @@
 **Dispatch:** Second of four finishing passes. Reads `draft.md` and the active style guide. Updates `draft.md` in place. Appends to `finishing-notes.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Style enforcer pass"
   prompt: |
     You are a style enforcer. You apply the active style guide's mechanical rules to

--- a/plugins/writing/skills/writing/interview-prompt.md
+++ b/plugins/writing/skills/writing/interview-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** First agent in the writing pipeline. Reads nothing. Writes `interview.md` (Q&A log) and `interview-synthesis.md` (extracted thinking).
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Interview the author"
   prompt: |
     You are an interview agent helping a writer prepare to draft a piece. Your job is

--- a/plugins/writing/skills/writing/outline-prompt.md
+++ b/plugins/writing/skills/writing/outline-prompt.md
@@ -5,7 +5,7 @@
 **Dispatch:** Second agent in the pipeline. Reads `interview-synthesis.md` and the active style guide. Writes `outline.md`.
 
 ```
-Agent tool (general-purpose):
+Dispatched agent prompt:
   description: "Negotiate outline"
   prompt: |
     You are an outline agent. You read the interview synthesis and propose a structure

--- a/tests/unit/test-codex-plugin-structure.sh
+++ b/tests/unit/test-codex-plugin-structure.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MARKETPLACE="$REPO_ROOT/.agents/plugins/marketplace.json"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+[ -f "$MARKETPLACE" ] || fail "Codex marketplace missing at .agents/plugins/marketplace.json"
+
+jq empty "$MARKETPLACE" || fail "Codex marketplace is not valid JSON"
+
+marketplace_name="$(jq -r '.name' "$MARKETPLACE")"
+[ "$marketplace_name" = "pgoell-claude-tools" ] || fail "Unexpected marketplace name: $marketplace_name"
+
+plugin_count="$(jq '.plugins | length' "$MARKETPLACE")"
+[ "$plugin_count" -eq 4 ] || fail "Expected 4 Codex marketplace plugins, got $plugin_count"
+
+for plugin in atlassian google-workspace research writing; do
+    plugin_dir="$REPO_ROOT/plugins/$plugin"
+    manifest="$plugin_dir/.codex-plugin/plugin.json"
+
+    [ -d "$plugin_dir/skills" ] || fail "$plugin skills directory missing"
+    [ -f "$manifest" ] || fail "$plugin Codex manifest missing"
+    jq empty "$manifest" || fail "$plugin Codex manifest is not valid JSON"
+
+    manifest_name="$(jq -r '.name' "$manifest")"
+    [ "$manifest_name" = "$plugin" ] || fail "$plugin manifest name mismatch: $manifest_name"
+
+    skills_path="$(jq -r '.skills' "$manifest")"
+    [ "$skills_path" = "./skills/" ] || fail "$plugin manifest must reuse ./skills/, got $skills_path"
+
+    display_name="$(jq -r '.interface.displayName // empty' "$manifest")"
+    [ -n "$display_name" ] || fail "$plugin manifest missing interface.displayName"
+
+    short_description="$(jq -r '.interface.shortDescription // empty' "$manifest")"
+    [ -n "$short_description" ] || fail "$plugin manifest missing interface.shortDescription"
+
+    marketplace_path="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .source.path' "$MARKETPLACE")"
+    [ "$marketplace_path" = "./plugins/$plugin" ] || fail "$plugin marketplace path mismatch: $marketplace_path"
+
+    marketplace_source="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .source.source' "$MARKETPLACE")"
+    [ "$marketplace_source" = "local" ] || fail "$plugin marketplace source must be local"
+
+    installation="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .policy.installation' "$MARKETPLACE")"
+    [ "$installation" = "AVAILABLE" ] || fail "$plugin marketplace installation policy mismatch: $installation"
+
+    authentication="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .policy.authentication' "$MARKETPLACE")"
+    [ "$authentication" = "ON_INSTALL" ] || fail "$plugin marketplace authentication policy mismatch: $authentication"
+
+    category="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .category' "$MARKETPLACE")"
+    [ -n "$category" ] || fail "$plugin marketplace category missing"
+done
+
+for skill in \
+    "$REPO_ROOT/plugins/research/skills/research/SKILL.md" \
+    "$REPO_ROOT/plugins/writing/skills/writing/SKILL.md" \
+    "$REPO_ROOT/plugins/writing/skills/pyramid/SKILL.md" \
+    "$REPO_ROOT/plugins/writing/skills/tech-doc/SKILL.md"; do
+    grep -q "## Platform Adaptation" "$skill" || fail "$skill missing Platform Adaptation section"
+    grep -q "Codex" "$skill" || fail "$skill missing Codex tool mapping"
+done
+
+if rg -q "Agent tool \\(general-purpose\\):" "$REPO_ROOT/plugins/research" "$REPO_ROOT/plugins/writing"; then
+    fail "Prompt templates still contain Claude specific Agent tool headers"
+fi
+
+echo "Codex plugin structure OK"

--- a/tests/unit/test-codex-plugin-structure.sh
+++ b/tests/unit/test-codex-plugin-structure.sh
@@ -54,7 +54,14 @@ for plugin in atlassian google-workspace research writing; do
 
     category="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .category' "$MARKETPLACE")"
     [ -n "$category" ] || fail "$plugin marketplace category missing"
+
+    marketplace_display_name="$(jq -r --arg plugin "$plugin" '.plugins[] | select(.name == $plugin) | .interface.displayName // empty' "$MARKETPLACE")"
+    [ -n "$marketplace_display_name" ] || fail "$plugin marketplace entry missing interface.displayName"
 done
+
+[ -L "$REPO_ROOT/CLAUDE.md" ] || fail "Root CLAUDE.md must be a symlink to AGENTS.md"
+[ "$(readlink "$REPO_ROOT/CLAUDE.md")" = "AGENTS.md" ] || fail "CLAUDE.md symlink must target AGENTS.md"
+[ -f "$REPO_ROOT/AGENTS.md" ] || fail "AGENTS.md missing at repo root"
 
 for skill in \
     "$REPO_ROOT/plugins/research/skills/research/SKILL.md" \


### PR DESCRIPTION
## Summary

Adds Codex plugin support while keeping the existing Claude Code skills as the single source of truth.

## Changes

- Add `.agents/plugins/marketplace.json` for Codex.
- Add `.codex-plugin/plugin.json` manifests for atlassian, google-workspace, research, and writing.
- Point every Codex manifest at the existing `./skills/` directory.
- Add platform adaptation guidance to orchestration-heavy skills for Codex and Claude Code tool mappings.
- Normalize dispatched prompt headers away from Claude-specific Agent tool wording.
- Document the shared Claude Code and Codex setup.
- Add a static unit test for Codex plugin structure and shared skill reuse.

## Validation

- `bash tests/unit/test-codex-plugin-structure.sh`
- `find .claude-plugin plugins .agents -name '*.json' -exec jq empty {} +`
- `find tests -name '*.sh' -exec bash -n {} +`
- `bash tests/unit/test-style-preset-structure.sh`
- `bash tests/unit/test-wordlist-format.sh`
- `git diff --check`

## Notes

The existing untracked `.claude/settings.json` file was left out of this PR.