### PR TITLE
feat(agents-md-management): port Anthropic CLAUDE.md plugin to runtime-agnostic AGENTS.md/CLAUDE.md skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -83,6 +83,22 @@
         "displayName": "Runtime Bridge",
         "shortDescription": "Make a project work with both Claude Code and Codex CLI"
       }
+    },
+    {
+      "name": "agents-md-management",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agents-md-management"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Agents.md Management",
+        "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "pgoell-claude-tools",
   "owner": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,12 @@
       "source": "./plugins/runtime-bridge",
       "description": "Bidirectionally align a project's Claude Code and Codex CLI configuration: memory files, subagents, hooks, settings",
       "version": "0.1.0"
+    },
+    {
+      "name": "agents-md-management",
+      "source": "./plugins/agents-md-management",
+      "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
+      "version": "0.1.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ tests/
 | `research` | 2.0.0 | `research` (multi-agent pipeline with review gates) |
 | `writing` | 1.6.0 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
+| `agents-md-management` | 0.1.0 | `agents-md-improver`, `agents-md-session-capture` |
 
 ## How to Develop a New Skill
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Create `.claude-plugin/plugin.json`:
 {
   "name": "<plugin-name>",
   "description": "<one-line description>",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["<relevant>", "<keywords>"]
 }
@@ -81,7 +81,7 @@ Create `.codex-plugin/plugin.json` for the same plugin. It must point to the exi
   "name": "<plugin-name>",
   "version": "<same-version-as-claude-plugin>",
   "description": "<one-line description>",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["<relevant>", "<keywords>"],
   "skills": "./skills/",
@@ -89,7 +89,7 @@ Create `.codex-plugin/plugin.json` for the same plugin. It must point to the exi
     "displayName": "<Plugin Display Name>",
     "shortDescription": "<short human-facing description>",
     "longDescription": "<long human-facing description>",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": ["Interactive", "Write"],
     "defaultPrompt": ["<starter prompt>"],

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Pascal Kraus
+Copyright (c) 2026 Pascal Göllner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `pyramid` | writing | Barbara Minto pyramid-principle outlines or restructures, with a parallel MECE / So-What / Q-A / Inductive-Deductive audit panel and SCQA opener |
 | `tech-doc` | writing | Diátaxis-aware technical documentation pipeline (tutorials, how-tos, references, explanations) with Microsoft and Google style-guide presets |
 | `claude-codex-bridge` | runtime-bridge | Align Claude Code and Codex artifacts in a project |
+| `agents-md-improver` | agents-md-management | Audit AGENTS.md / CLAUDE.md across project and user-global scopes; propose targeted edits |
+| `agents-md-session-capture` | agents-md-management | Capture session learnings into AGENTS.md / CLAUDE.md (or `*.local.md`, or user-global) by scope |
 
 ## Plugins
 
@@ -59,6 +61,14 @@ Aligns Claude Code and Codex artifacts across a project. When Claude Code and Co
 **Skills:**
 - `/pgoell-claude-tools:claude-codex-bridge`: Analyze and align Claude Code and Codex artifacts
 
+### agents-md-management
+
+Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and variants like `AGENTS.local.md`, `CLAUDE.local.md`, `.claude.md`, `.claude.local.md`, plus user-global `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`). Symlink-aware via `realpath`, so `CLAUDE.md` symlinked to `AGENTS.md` counts as one logical file. Derived from Anthropic's `claude-md-management` plugin by Isabella He, with adaptations for cross-runtime use.
+
+**Skills:**
+- `/pgoell-claude-tools:agents-md-improver`: Periodic cold audit. Scores each file against a six-criterion rubric, outputs a quality report, then proposes targeted edits with confirmation.
+- `/pgoell-claude-tools:agents-md-session-capture`: End-of-session warm capture. Reflects on what context was missing, classifies each learning by scope (project-shared, project-local, user-global), and routes additions to the right file. Triggers on `/revise-agents-md` or `/revise-claude-md`.
+
 ## Installation
 
 ### Claude Code
@@ -70,6 +80,7 @@ Aligns Claude Code and Codex artifacts across a project. When Claude Code and Co
 /plugin install research@pgoell-claude-tools
 /plugin install writing@pgoell-claude-tools
 /plugin install runtime-bridge@pgoell-claude-tools
+/plugin install agents-md-management@pgoell-claude-tools
 ```
 
 ### Codex
@@ -87,7 +98,7 @@ codex
 /plugins
 ```
 
-In the picker, install `atlassian`, `google-workspace`, `research`, and `writing`.
+In the picker, install `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`, and `agents-md-management`.
 
 `codex plugin marketplace add` accepts `owner/repo[@ref]`, an HTTPS or SSH Git URL, or a local marketplace root directory. The marketplace file lives at `.agents/plugins/marketplace.json` and the per-plugin Codex manifests live at `plugins/<plugin>/.codex-plugin/plugin.json`. Both reuse the same `plugins/<plugin>/skills/` directories as Claude Code, single sourced.
 
@@ -133,3 +144,7 @@ No authentication required. The research plugin uses the host agent's web search
 ### runtime-bridge
 
 No setup required. In any project, ask the skill to align Claude Code and Codex artifacts (e.g. "make this project work with both Claude Code and Codex"). After the first apply that writes into `.codex/`, run `codex` once in that project and accept the trust prompt.
+
+### agents-md-management
+
+No setup required. In any project, ask either skill: "audit my CLAUDE.md files" (cold audit) or "update AGENTS.md with what we learned this session" (warm capture). Operates on local agent-instruction files only; no network or auth.

--- a/docs/superpowers/plans/2026-05-04-agents-md-management.md
+++ b/docs/superpowers/plans/2026-05-04-agents-md-management.md
@@ -1,0 +1,1146 @@
+# agents-md-management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port Anthropic's `claude-md-management` plugin (one skill + one slash command) into a runtime-agnostic, two-skill plugin in this marketplace, working in both Claude Code and Codex CLI.
+
+**Architecture:** New plugin `plugins/agents-md-management/` with two skills: `agents-md-improver` (cold audit) and `agents-md-session-capture` (warm end-of-session capture). Reference docs ported verbatim from upstream. Shared discovery glob covers `AGENTS.md`/`CLAUDE.md` plus their variants and user-global memory files; symlinked pairs are deduped via `realpath`. Both skills include a Platform Adaptation table mapping Claude Code tool names to Codex equivalents.
+
+**Tech Stack:** Markdown skill files, JSON plugin manifests, Bash unit tests via the repo's existing `tests/test-helpers.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-agents-md-management-design.md`
+
+**Upstream source path (read-only):**
+`/home/pascal/.claude/plugins/marketplaces/claude-plugins-official/plugins/claude-md-management/`
+
+**Licensing note:** Upstream is Apache 2.0. This plugin's LICENSE is MIT for our additions. A NOTICE file at the plugin root attributes the ported portions (reference docs and skill workflows derived from upstream) to Anthropic / Isabella He under Apache 2.0. Apache 2.0 and MIT are compatible; the NOTICE preserves Apache's attribution requirement.
+
+---
+
+## File Structure
+
+```
+plugins/agents-md-management/
+├── .claude-plugin/
+│   └── plugin.json                          # NEW — Claude Code manifest
+├── .codex-plugin/
+│   └── plugin.json                          # NEW — Codex manifest, "skills": "./skills/"
+├── LICENSE                                  # NEW — MIT
+├── NOTICE                                   # NEW — Apache 2.0 attribution for ported content
+├── README.md                                # NEW — usage + upstream credit
+└── skills/
+    ├── agents-md-improver/
+    │   ├── SKILL.md                         # NEW — adapted port
+    │   └── references/
+    │       ├── quality-criteria.md          # NEW — verbatim copy from upstream
+    │       ├── templates.md                 # NEW — verbatim copy from upstream
+    │       └── update-guidelines.md         # NEW — verbatim copy from upstream
+    └── agents-md-session-capture/
+        └── SKILL.md                         # NEW — adapted from upstream's /revise-claude-md command
+
+.claude-plugin/marketplace.json              # MODIFY — append plugin entry
+.agents/plugins/marketplace.json             # MODIFY — append plugin entry
+README.md                                    # MODIFY — add to Plugins table
+
+tests/skill-triggering/prompts/
+├── agents-md-audit.txt                      # NEW
+├── agents-md-audit-agents.txt               # NEW
+├── agents-md-session-capture.txt            # NEW
+├── agents-md-session-capture-cmd.txt        # NEW
+└── agents-md-global-audit.txt               # NEW
+
+tests/unit/
+└── test-agents-md-skills.sh                 # NEW
+```
+
+---
+
+## Task 1: Scaffold plugin directory + manifests + LICENSE/NOTICE/README
+
+**Files:**
+- Create: `plugins/agents-md-management/.claude-plugin/plugin.json`
+- Create: `plugins/agents-md-management/.codex-plugin/plugin.json`
+- Create: `plugins/agents-md-management/LICENSE`
+- Create: `plugins/agents-md-management/NOTICE`
+- Create: `plugins/agents-md-management/README.md`
+
+- [ ] **Step 1: Create the directory tree**
+
+```bash
+mkdir -p plugins/agents-md-management/.claude-plugin
+mkdir -p plugins/agents-md-management/.codex-plugin
+mkdir -p plugins/agents-md-management/skills/agents-md-improver/references
+mkdir -p plugins/agents-md-management/skills/agents-md-session-capture
+```
+
+- [ ] **Step 2: Write `plugins/agents-md-management/.claude-plugin/plugin.json`**
+
+```json
+{
+  "name": "agents-md-management",
+  "version": "0.1.0",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope.",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"]
+}
+```
+
+- [ ] **Step 3: Write `plugins/agents-md-management/.codex-plugin/plugin.json`**
+
+```json
+{
+  "name": "agents-md-management",
+  "version": "0.1.0",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files; capture session learnings",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agents.md Management",
+    "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings",
+    "longDescription": "Two skills for keeping agent-instruction files current. agents-md-improver runs a periodic cold audit, scoring each file against a six-criterion rubric and proposing targeted edits. agents-md-session-capture runs an end-of-session warm capture, classifying each learning by scope (project-shared, project-local, user-global) and routing edits to the right file. Discovery is symlink-aware via realpath, so paired CLAUDE.md/AGENTS.md count as one logical file. User-global memory files (~/.claude/CLAUDE.md, ~/.codex/AGENTS.md) are included in the default sweep.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "defaultPrompt": [
+      "Audit my CLAUDE.md and AGENTS.md files",
+      "Update AGENTS.md with what we learned this session",
+      "Check if my agent instructions are up to date"
+    ],
+    "screenshots": []
+  }
+}
+```
+
+- [ ] **Step 4: Write `plugins/agents-md-management/LICENSE` (MIT)**
+
+```text
+MIT License
+
+Copyright (c) 2026 Pascal Kraus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+- [ ] **Step 5: Write `plugins/agents-md-management/NOTICE`**
+
+```text
+agents-md-management
+Copyright 2026 Pascal Kraus
+
+This plugin contains content derived from Anthropic's claude-md-management
+plugin (https://github.com/anthropics/claude-plugins), authored by Isabella He,
+licensed under the Apache License, Version 2.0:
+
+  - skills/agents-md-improver/SKILL.md
+      (workflow phases, quality rubric structure, report format)
+  - skills/agents-md-improver/references/quality-criteria.md (verbatim)
+  - skills/agents-md-improver/references/templates.md         (verbatim)
+  - skills/agents-md-improver/references/update-guidelines.md (verbatim)
+  - skills/agents-md-session-capture/SKILL.md
+      (adapted from upstream's /revise-claude-md slash command)
+
+Apache License 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Adaptations are licensed under MIT (see LICENSE) where they qualify as
+original work; preserved upstream content remains under Apache 2.0.
+```
+
+- [ ] **Step 6: Write `plugins/agents-md-management/README.md`**
+
+````markdown
+# agents-md-management
+
+Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and their variants) so the host agent in any runtime has current, well-organized project context.
+
+Two skills:
+
+| | Purpose | Triggered by |
+|---|---|---|
+| `agents-md-improver` | Periodic cold audit against the codebase | "audit my CLAUDE.md", "check if AGENTS.md is up to date" |
+| `agents-md-session-capture` | End-of-session warm capture of learnings | "/revise-agents-md", "update AGENTS.md with what we learned this session" |
+
+Works in Claude Code and Codex CLI. Files are deduped via `realpath`, so `CLAUDE.md` symlinked to `AGENTS.md` counts as one logical file.
+
+## Files in scope
+
+- `AGENTS.md`, `AGENTS.local.md`
+- `CLAUDE.md`, `CLAUDE.local.md`
+- `.claude.md`, `.claude.local.md` (legacy lowercase from upstream)
+- `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` (user-global, included so generalizable rules can be hoisted)
+
+`GEMINI.md` and other runtime variants are out of scope.
+
+## Usage
+
+```text
+audit my CLAUDE.md files
+check if AGENTS.md is up to date
+update AGENTS.md with what we learned this session
+/revise-agents-md
+/revise-claude-md
+```
+
+## Credits
+
+Derived from Anthropic's [`claude-md-management`](https://github.com/anthropics/claude-plugins/tree/main/plugins/claude-md-management) plugin by Isabella He, licensed under Apache 2.0. The reference docs under `skills/agents-md-improver/references/` are imported verbatim. See `NOTICE` for full attribution.
+
+This plugin is licensed MIT (`LICENSE`).
+````
+
+- [ ] **Step 7: Verify the manifests parse**
+
+```bash
+jq empty plugins/agents-md-management/.claude-plugin/plugin.json
+jq empty plugins/agents-md-management/.codex-plugin/plugin.json
+```
+
+Expected: no output, exit 0 for both.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plugins/agents-md-management/.claude-plugin/plugin.json \
+        plugins/agents-md-management/.codex-plugin/plugin.json \
+        plugins/agents-md-management/LICENSE \
+        plugins/agents-md-management/NOTICE \
+        plugins/agents-md-management/README.md
+git commit -m "feat(agents-md-management): scaffold plugin manifests, license, readme"
+```
+
+---
+
+## Task 2: Port reference docs verbatim from upstream
+
+**Files:**
+- Create: `plugins/agents-md-management/skills/agents-md-improver/references/quality-criteria.md`
+- Create: `plugins/agents-md-management/skills/agents-md-improver/references/templates.md`
+- Create: `plugins/agents-md-management/skills/agents-md-improver/references/update-guidelines.md`
+
+These are imported verbatim from upstream because they describe content quality (rubric scoring, CLAUDE.md templates, update do's-and-don'ts), which is runtime-agnostic. Do not edit them.
+
+- [ ] **Step 1: Copy the three reference files verbatim**
+
+```bash
+UPSTREAM=/home/pascal/.claude/plugins/marketplaces/claude-plugins-official/plugins/claude-md-management/skills/claude-md-improver/references
+DEST=plugins/agents-md-management/skills/agents-md-improver/references
+
+cp "$UPSTREAM/quality-criteria.md"   "$DEST/quality-criteria.md"
+cp "$UPSTREAM/templates.md"          "$DEST/templates.md"
+cp "$UPSTREAM/update-guidelines.md"  "$DEST/update-guidelines.md"
+```
+
+- [ ] **Step 2: Verify the copies are byte-identical**
+
+```bash
+diff -r "$UPSTREAM" "$DEST"
+```
+
+Expected: no output, exit 0. Diff should report no differences.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/agents-md-management/skills/agents-md-improver/references/
+git commit -m "feat(agents-md-management): port reference docs verbatim from upstream"
+```
+
+---
+
+## Task 3: Write `agents-md-improver/SKILL.md` (adapted port)
+
+**Files:**
+- Create: `plugins/agents-md-management/skills/agents-md-improver/SKILL.md`
+
+The skill is a faithful port of upstream's `claude-md-improver/SKILL.md`. Three changes from upstream:
+
+1. Frontmatter `name` is `agents-md-improver` (not `claude-md-improver`); description lists synonyms (CLAUDE.md, AGENTS.md, "agent instructions", "memory file") so it triggers regardless of which name the user uses.
+2. Discovery section uses the new glob (six file variants + user-global) and dedupes via `realpath`.
+3. Replace "Claude auto-discovers" prose with "the host agent auto-discovers"; add the Platform Adaptation table.
+
+Reference doc links unchanged (still `references/quality-criteria.md` etc.).
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+---
+name: agents-md-improver
+description: Audit and improve AGENTS.md / CLAUDE.md files (and variants like AGENTS.local.md, CLAUDE.local.md, .claude.md, .claude.local.md, plus user-global ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md) in repositories. Use when user asks to check, audit, update, improve, or fix agent-instruction files. Scans for all variants, dedupes symlinked pairs via realpath, evaluates quality against a six-criterion rubric, outputs a quality report, then makes targeted updates. Also triggers on "CLAUDE.md maintenance", "AGENTS.md audit", "project memory optimization", or "agent instructions audit".
+tools: Read, Glob, Grep, Bash, Edit
+---
+
+# Agents.md Improver
+
+Audit, evaluate, and improve agent-instruction files (AGENTS.md, CLAUDE.md, and variants) across a codebase to ensure the host agent has optimal project context.
+
+**This skill can write to agent-instruction files.** After presenting a quality report and getting user approval, it updates files with targeted improvements.
+
+## Platform Adaptation
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Find files | `Glob` / `Grep` | `shell` (`find`, `grep`) |
+| Read a file | `Read` | `shell` (`cat`) |
+| Edit a file | `Edit` | `apply_patch` / `shell` heredoc |
+| User confirmation | `AskUserQuestion` | `ask_user` / built-in approval prompt |
+| Shell commands | `Bash` | `shell` |
+
+The skill body refers to actions abstractly ("read the file", "apply the diff"). The host agent maps to its own tool inventory.
+
+## Workflow
+
+### Phase 1: Discovery
+
+Find every agent-instruction file in scope (project + user-global), dedupe symlinked pairs via `realpath`:
+
+```bash
+{
+  find . \( \
+      -name "AGENTS.md" \
+      -o -name "AGENTS.local.md" \
+      -o -name "CLAUDE.md" \
+      -o -name "CLAUDE.local.md" \
+      -o -name ".claude.md" \
+      -o -name ".claude.local.md" \
+    \) -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+  ls ~/.claude/CLAUDE.md ~/.codex/AGENTS.md 2>/dev/null
+} | xargs -I{} realpath {} | sort -u
+```
+
+**File Types & Locations:**
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| Project-shared | `./AGENTS.md`, `./CLAUDE.md`, `./.claude.md` | Primary project context, in git, shared with team |
+| Project-local | `./AGENTS.local.md`, `./CLAUDE.local.md`, `./.claude.local.md` | Personal overrides, gitignored |
+| User-global | `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` | User-wide defaults across all projects |
+| Package-specific | `./packages/*/AGENTS.md`, `./packages/*/CLAUDE.md` | Module-level context in monorepos |
+| Subdirectory | Any nested location | Feature/domain-specific context |
+
+**Note:** The host agent auto-discovers agent-instruction files in parent directories, making monorepo setups work automatically. When two paths share the same `realpath` (typical when CLAUDE.md is a symlink to AGENTS.md), audit them as one logical file and edit the canonical realpath target.
+
+### Phase 2: Quality Assessment
+
+For each unique file, evaluate against quality criteria. See [references/quality-criteria.md](references/quality-criteria.md) for detailed rubrics.
+
+**Scope-aware lens:** the assessment lens shifts per scope. For project files: "is this codebase well-documented for an agent?". For user-global files: "are these rules organized, non-contradictory, at the right abstraction level, and not duplicated across projects?".
+
+**Quick Assessment Checklist:**
+
+| Criterion | Weight | Check |
+|-----------|--------|-------|
+| Commands/workflows documented | High | Are build/test/deploy commands present? |
+| Architecture clarity | High | Can the host agent understand the codebase structure? |
+| Non-obvious patterns | Medium | Are gotchas and quirks documented? |
+| Conciseness | Medium | No verbose explanations or obvious info? |
+| Currency | High | Does it reflect current codebase state? |
+| Actionability | High | Are instructions executable, not vague? |
+
+**Quality Scores:**
+- **A (90-100)**: Comprehensive, current, actionable
+- **B (70-89)**: Good coverage, minor gaps
+- **C (50-69)**: Basic info, missing key sections
+- **D (30-49)**: Sparse or outdated
+- **F (0-29)**: Missing or severely outdated
+
+### Phase 3: Quality Report Output
+
+**ALWAYS output the quality report BEFORE making any updates.**
+
+Format:
+
+```
+## Agents.md Quality Report
+
+### Summary
+- Files found: X (Y unique after realpath dedup)
+- Average score: X/100
+- Files needing update: X
+
+### File-by-File Assessment
+
+#### 1. ./AGENTS.md (Project-shared) — also reachable as ./CLAUDE.md (symlink)
+**Score: XX/100 (Grade: X)**
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Commands/workflows | X/20 | ... |
+| Architecture clarity | X/20 | ... |
+| Non-obvious patterns | X/15 | ... |
+| Conciseness | X/15 | ... |
+| Currency | X/15 | ... |
+| Actionability | X/15 | ... |
+
+**Issues:**
+- [List specific problems]
+
+**Recommended additions:**
+- [List what should be added]
+
+#### 2. ./packages/api/AGENTS.md (Package-specific)
+...
+```
+
+### Phase 4: Targeted Updates
+
+After outputting the quality report, ask user for confirmation before updating.
+
+**Update Guidelines (Critical):**
+
+1. **Propose targeted additions only** — focus on genuinely useful info:
+   - Commands or workflows discovered during analysis
+   - Gotchas or non-obvious patterns found in code
+   - Package relationships that weren't clear
+   - Testing approaches that work
+   - Configuration quirks
+
+2. **Keep it minimal** — avoid:
+   - Restating what's obvious from the code
+   - Generic best practices already covered
+   - One-off fixes unlikely to recur
+   - Verbose explanations when a one-liner suffices
+
+3. **Show diffs** — for each change, show:
+   - Which file to update (use the canonical realpath)
+   - The specific addition (as a diff or quoted block)
+   - Brief explanation of why this helps future sessions
+
+**Diff Format:**
+
+````markdown
+### Update: ./AGENTS.md
+
+**Why:** Build command was missing, causing confusion about how to run the project.
+
+```diff
++ ## Quick Start
++
++ ```bash
++ npm install
++ npm run dev  # Start development server on port 3000
++ ```
+```
+````
+
+### Phase 5: Apply Updates
+
+After user approval, apply changes (see Platform Adaptation for the right edit tool). Preserve existing content structure. Edit the canonical realpath target only — symlinks update automatically.
+
+## Templates
+
+See [references/templates.md](references/templates.md) for templates by project type.
+
+## Update Guidelines Reference
+
+See [references/update-guidelines.md](references/update-guidelines.md) for full do's and don'ts.
+
+## Common Issues to Flag
+
+1. **Stale commands**: build commands that no longer work
+2. **Missing dependencies**: required tools not mentioned
+3. **Outdated architecture**: file structure that's changed
+4. **Missing environment setup**: required env vars or config
+5. **Broken test commands**: test scripts that have changed
+6. **Undocumented gotchas**: non-obvious patterns not captured
+7. **Scope mismatch**: project-specific rules in the user-global file (or vice versa)
+8. **Duplicate rules**: same rule stated in both project and user-global file
+
+## User Tips to Share
+
+When presenting recommendations, remind users:
+
+- **`#` key shortcut (Claude Code)**: during a Claude Code session, press `#` to have Claude auto-incorporate learnings into the project memory file
+- **Keep it concise**: agent-instruction files should be human-readable; dense is better than verbose
+- **Actionable commands**: all documented commands should be copy-paste ready
+- **Use `*.local.md`**: for personal preferences not shared with team (add to `.gitignore`)
+- **Global defaults**: put user-wide preferences in `~/.claude/CLAUDE.md` or `~/.codex/AGENTS.md`
+- **Symlink for cross-runtime parity**: if you use both Claude Code and Codex, symlink `CLAUDE.md` → `AGENTS.md` so a single file serves both
+
+## What Makes a Great Agent-Instruction File
+
+**Key principles:**
+- Concise and human-readable
+- Actionable commands that can be copy-pasted
+- Project-specific patterns, not generic advice
+- Non-obvious gotchas and warnings
+
+**Recommended sections** (use only what's relevant):
+- Commands (build, test, dev, lint)
+- Architecture (directory structure)
+- Key Files (entry points, config)
+- Code Style (project conventions)
+- Environment (required vars, setup)
+- Testing (commands, patterns)
+- Gotchas (quirks, common mistakes)
+- Workflow (when to do what)
+````
+
+- [ ] **Step 2: Verify file size and references**
+
+```bash
+wc -l plugins/agents-md-management/skills/agents-md-improver/SKILL.md
+ls plugins/agents-md-management/skills/agents-md-improver/references/
+```
+
+Expected: SKILL.md should be ~180–220 lines. References dir should contain `quality-criteria.md`, `templates.md`, `update-guidelines.md`.
+
+- [ ] **Step 3: Verify discovery snippet is well-formed**
+
+```bash
+grep -A 12 'find \\.' plugins/agents-md-management/skills/agents-md-improver/SKILL.md | head -15
+```
+
+Expected: prints the discovery glob block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/agents-md-management/skills/agents-md-improver/SKILL.md
+git commit -m "feat(agents-md-management): add agents-md-improver skill"
+```
+
+---
+
+## Task 4: Write `agents-md-session-capture/SKILL.md`
+
+**Files:**
+- Create: `plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md`
+
+This skill replaces upstream's `/revise-claude-md` slash command. Codex has no slash commands, so it must be a skill. Description triggers on `/revise-claude-md` and `/revise-agents-md` so users typing the legacy form still get routed correctly.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+---
+name: agents-md-session-capture
+description: Capture learnings from the current session and update AGENTS.md / CLAUDE.md (and variants, including user-global ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md) with context that would help future sessions. Use when the user wants to "update CLAUDE.md with what we learned", "capture session learnings", "revise AGENTS.md", or types "/revise-agents-md" or "/revise-claude-md". Routes each learning to the right file by scope: project-specific learnings to AGENTS.md/CLAUDE.md, personal overrides to *.local.md, generalizable rules to the user-global file.
+tools: Read, Glob, Grep, Bash, Edit
+---
+
+# Agents.md Session Capture
+
+Review the current session for context that was missing and would have helped the host agent. Propose targeted additions to the right agent-instruction file by scope.
+
+## Platform Adaptation
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Find files | `Glob` / `Grep` | `shell` (`find`, `grep`) |
+| Read a file | `Read` | `shell` (`cat`) |
+| Edit a file | `Edit` | `apply_patch` / `shell` heredoc |
+| User confirmation | `AskUserQuestion` | `ask_user` / built-in approval prompt |
+| Shell commands | `Bash` | `shell` |
+
+The skill body refers to actions abstractly. The host agent maps to its own tool inventory.
+
+## Step 1: Reflect
+
+What context was missing during this session that would have helped the host agent?
+
+- Bash commands that were used or discovered
+- Code style patterns followed
+- Testing approaches that worked
+- Environment / configuration quirks
+- Warnings or gotchas encountered
+- Tool preferences (e.g. "always use ripgrep over grep here")
+
+## Step 2: Discover candidate files
+
+Find every agent-instruction file in scope (project + user-global), dedupe symlinked pairs via `realpath`:
+
+```bash
+{
+  find . \( \
+      -name "AGENTS.md" \
+      -o -name "AGENTS.local.md" \
+      -o -name "CLAUDE.md" \
+      -o -name "CLAUDE.local.md" \
+      -o -name ".claude.md" \
+      -o -name ".claude.local.md" \
+    \) -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+  ls ~/.claude/CLAUDE.md ~/.codex/AGENTS.md 2>/dev/null
+} | xargs -I{} realpath {} | sort -u
+```
+
+When two paths share the same `realpath`, treat them as one logical file. Edits target the canonical realpath.
+
+## Step 3: Classify each learning by scope
+
+Decide where each addition belongs before drafting it:
+
+| Scope | Target file | Examples |
+|---|---|---|
+| Project-shared | `AGENTS.md` / `CLAUDE.md` (canonical) | Build commands, this codebase's quirks, team-wide conventions |
+| Project-local | `AGENTS.local.md` / `CLAUDE.local.md` | Your personal overrides for this project, not for the team |
+| User-global | `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` | Cross-project rules: writing style, tool preferences, system-wide preferences |
+
+If a learning is generic enough to apply to other projects, route it to the user-global file rather than this project's AGENTS.md. Avoid duplication: if a rule already exists in the user-global file, don't restate it project-locally.
+
+## Step 4: Draft additions
+
+**Keep it concise** — one line per concept. Agent-instruction files are part of the prompt, so brevity matters.
+
+Format: `<command or pattern>` — `<brief description>`
+
+Avoid:
+- Verbose explanations
+- Obvious information
+- One-off fixes unlikely to recur
+
+## Step 5: Show proposed changes
+
+For each addition:
+
+````markdown
+### Update: ./AGENTS.md
+
+**Why:** [one-line reason]
+
+```diff
++ [the addition — keep it brief]
+```
+````
+
+Group by target file. Show all proposed edits to one file together.
+
+## Step 6: Apply with approval
+
+Ask if the user wants to apply the changes. Only edit files they approve. Use the right edit tool per Platform Adaptation. Edit the canonical realpath target only — symlinks update automatically.
+````
+
+- [ ] **Step 2: Verify the file**
+
+```bash
+wc -l plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
+grep -c 'realpath' plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
+```
+
+Expected: ~80–110 lines. `realpath` should appear at least 2 times (in the discovery snippet and the dedup note).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
+git commit -m "feat(agents-md-management): add agents-md-session-capture skill"
+```
+
+---
+
+## Task 5: Register in Claude Code marketplace
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Inspect current state**
+
+```bash
+jq '.plugins | length' .claude-plugin/marketplace.json
+jq '.plugins[].name' .claude-plugin/marketplace.json
+```
+
+Expected: 5 plugins, names include `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`.
+
+- [ ] **Step 2: Append the new plugin entry using `jq`**
+
+```bash
+jq '.plugins += [{
+  "name": "agents-md-management",
+  "source": "./plugins/agents-md-management",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
+  "version": "0.1.0"
+}]' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp \
+&& mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+jq '.plugins | length' .claude-plugin/marketplace.json
+jq '.plugins[-1]' .claude-plugin/marketplace.json
+```
+
+Expected: 6 plugins; last entry matches the new plugin block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude-plugin/marketplace.json
+git commit -m "feat(agents-md-management): register in Claude Code marketplace"
+```
+
+---
+
+## Task 6: Register in Codex marketplace
+
+**Files:**
+- Modify: `.agents/plugins/marketplace.json`
+
+- [ ] **Step 1: Inspect current state**
+
+```bash
+jq '.plugins | length' .agents/plugins/marketplace.json
+jq '.plugins[].name' .agents/plugins/marketplace.json
+```
+
+Expected: 5 plugins.
+
+- [ ] **Step 2: Append the new entry**
+
+```bash
+jq '.plugins += [{
+  "name": "agents-md-management",
+  "source": { "source": "local", "path": "./plugins/agents-md-management" },
+  "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+  "category": "Productivity",
+  "interface": {
+    "displayName": "Agents.md Management",
+    "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
+  }
+}]' .agents/plugins/marketplace.json > .agents/plugins/marketplace.json.tmp \
+&& mv .agents/plugins/marketplace.json.tmp .agents/plugins/marketplace.json
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+jq '.plugins | length' .agents/plugins/marketplace.json
+jq '.plugins[-1]' .agents/plugins/marketplace.json
+```
+
+Expected: 6 plugins; last entry matches the new block above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .agents/plugins/marketplace.json
+git commit -m "feat(agents-md-management): register in Codex marketplace"
+```
+
+---
+
+## Task 7: Skill-triggering test prompts
+
+**Files:**
+- Create: `tests/skill-triggering/prompts/agents-md-audit.txt`
+- Create: `tests/skill-triggering/prompts/agents-md-audit-agents.txt`
+- Create: `tests/skill-triggering/prompts/agents-md-session-capture.txt`
+- Create: `tests/skill-triggering/prompts/agents-md-session-capture-cmd.txt`
+- Create: `tests/skill-triggering/prompts/agents-md-global-audit.txt`
+
+Each file is a single natural-language prompt; the test runner asserts that the named skill triggers.
+
+- [ ] **Step 1: Write `agents-md-audit.txt`**
+
+```text
+Audit my CLAUDE.md files and tell me where the gaps are.
+```
+
+- [ ] **Step 2: Write `agents-md-audit-agents.txt`**
+
+```text
+Check if my AGENTS.md is up to date with the current codebase.
+```
+
+- [ ] **Step 3: Write `agents-md-session-capture.txt`**
+
+```text
+Update AGENTS.md with what we learned during this session.
+```
+
+- [ ] **Step 4: Write `agents-md-session-capture-cmd.txt`**
+
+```text
+/revise-agents-md
+```
+
+- [ ] **Step 5: Write `agents-md-global-audit.txt`**
+
+```text
+Audit my global ~/.claude/CLAUDE.md and let me know if any rules belong in a project file instead.
+```
+
+- [ ] **Step 6: Sanity-check the prompt files**
+
+```bash
+ls tests/skill-triggering/prompts/agents-md-*.txt
+wc -l tests/skill-triggering/prompts/agents-md-*.txt
+```
+
+Expected: 5 files listed; each 1–2 lines.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/skill-triggering/prompts/agents-md-*.txt
+git commit -m "test(agents-md-management): skill-triggering prompts"
+```
+
+---
+
+## Task 8: Unit test (TDD-style: write, fail, fix to green)
+
+**Files:**
+- Create: `tests/unit/test-agents-md-skills.sh`
+
+Asserts skill loading, content fidelity, and structural invariants. Follows the pattern of `tests/unit/test-claude-codex-bridge-skill.sh`.
+
+- [ ] **Step 1: Write the test script**
+
+```bash
+#!/usr/bin/env bash
+# Test: agents-md-improver and agents-md-session-capture skills
+# Verifies the skills load, mention both AGENTS.md and CLAUDE.md, include
+# realpath dedup, the Platform Adaptation table, and reference docs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)/plugins/agents-md-management"
+
+echo "=== Test: agents-md-management plugin structure ==="
+echo ""
+
+# Test 1: Plugin manifest files exist and parse
+echo "Test 1: Plugin manifests exist and parse..."
+if [ -f "$PLUGIN_ROOT/.claude-plugin/plugin.json" ] \
+   && jq empty "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null; then
+    echo "  [PASS] .claude-plugin/plugin.json exists and parses"
+else
+    echo "  [FAIL] .claude-plugin/plugin.json missing or malformed"
+    exit 1
+fi
+if [ -f "$PLUGIN_ROOT/.codex-plugin/plugin.json" ] \
+   && jq empty "$PLUGIN_ROOT/.codex-plugin/plugin.json" 2>/dev/null; then
+    echo "  [PASS] .codex-plugin/plugin.json exists and parses"
+else
+    echo "  [FAIL] .codex-plugin/plugin.json missing or malformed"
+    exit 1
+fi
+echo ""
+
+# Test 2: Both skills' SKILL.md files exist
+echo "Test 2: Skill files exist..."
+for skill in agents-md-improver agents-md-session-capture; do
+    if [ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]; then
+        echo "  [PASS] skills/$skill/SKILL.md exists"
+    else
+        echo "  [FAIL] skills/$skill/SKILL.md missing"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 3: Reference docs exist and are non-empty
+echo "Test 3: Reference docs exist..."
+for ref in quality-criteria.md templates.md update-guidelines.md; do
+    f="$PLUGIN_ROOT/skills/agents-md-improver/references/$ref"
+    if [ -s "$f" ]; then
+        echo "  [PASS] references/$ref exists"
+    else
+        echo "  [FAIL] references/$ref missing or empty"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 4: Both skill bodies mention AGENTS.md and CLAUDE.md
+echo "Test 4: Both skill bodies mention AGENTS.md and CLAUDE.md..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q 'AGENTS\.md' && echo "$body" | grep -q 'CLAUDE\.md'; then
+        echo "  [PASS] $skill mentions both"
+    else
+        echo "  [FAIL] $skill missing one of AGENTS.md / CLAUDE.md"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 5: Both skill bodies mention realpath (dedup hint, embedded in shared discovery snippet)
+echo "Test 5: Both skill bodies mention realpath..."
+for skill in agents-md-improver agents-md-session-capture; do
+    if grep -q 'realpath' "$PLUGIN_ROOT/skills/$skill/SKILL.md"; then
+        echo "  [PASS] $skill mentions realpath"
+    else
+        echo "  [FAIL] $skill missing realpath dedup snippet"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 6: Both skill bodies include Platform Adaptation table
+echo "Test 6: Both skill bodies have Platform Adaptation table..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q '## Platform Adaptation' \
+       && echo "$body" | grep -q 'Claude Code' \
+       && echo "$body" | grep -q 'Codex'; then
+        echo "  [PASS] $skill has Platform Adaptation table"
+    else
+        echo "  [FAIL] $skill missing Platform Adaptation table"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 7: agents-md-improver SKILL.md references the three reference docs by name
+echo "Test 7: agents-md-improver references all three docs..."
+body="$(cat "$PLUGIN_ROOT/skills/agents-md-improver/SKILL.md")"
+for ref in quality-criteria.md templates.md update-guidelines.md; do
+    if echo "$body" | grep -q "references/$ref"; then
+        echo "  [PASS] references $ref"
+    else
+        echo "  [FAIL] missing reference to $ref"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 8: User-global memory files mentioned in both skill bodies
+echo "Test 8: User-global files mentioned in both skill bodies..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q '~/.claude/CLAUDE.md' \
+       && echo "$body" | grep -q '~/.codex/AGENTS.md'; then
+        echo "  [PASS] $skill includes both user-global paths"
+    else
+        echo "  [FAIL] $skill missing one or both user-global paths"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 9: Skill descriptions trigger on the right phrases
+echo "Test 9: Description fields mention key trigger phrases..."
+improver_body="$(cat "$PLUGIN_ROOT/skills/agents-md-improver/SKILL.md")"
+capture_body="$(cat "$PLUGIN_ROOT/skills/agents-md-session-capture/SKILL.md")"
+
+improver_desc=$(echo "$improver_body" | awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag')
+capture_desc=$(echo "$capture_body" | awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag')
+
+if echo "$improver_desc" | grep -qiE 'audit|improve|fix'; then
+    echo "  [PASS] improver description mentions audit/improve/fix"
+else
+    echo "  [FAIL] improver description missing audit/improve/fix"
+    exit 1
+fi
+
+if echo "$capture_desc" | grep -qiE 'session|learned|capture|revise'; then
+    echo "  [PASS] capture description mentions session/learned/capture/revise"
+else
+    echo "  [FAIL] capture description missing session/learned/capture/revise"
+    exit 1
+fi
+
+if echo "$capture_desc" | grep -q '/revise-claude-md' \
+   && echo "$capture_desc" | grep -q '/revise-agents-md'; then
+    echo "  [PASS] capture description mentions both legacy and new slash forms"
+else
+    echo "  [FAIL] capture description missing one of the slash forms"
+    exit 1
+fi
+echo ""
+
+echo "=== Tests complete ==="
+```
+
+- [ ] **Step 2: Make it executable and run it (expect PASS for all 9 tests)**
+
+```bash
+chmod +x tests/unit/test-agents-md-skills.sh
+bash tests/unit/test-agents-md-skills.sh
+```
+
+Expected: every assertion `[PASS]`, final line `=== Tests complete ===`.
+
+- [ ] **Step 3: If any test FAILs, fix the corresponding skill or manifest file (do not edit the test). Re-run until all pass.**
+
+Common failure modes:
+- Test 4/8 failure on `agents-md-session-capture`: likely missing `~/.claude/CLAUDE.md` reference in the skill body — re-check Step 3 of that skill.
+- Test 5 failure: `realpath` not in one of the SKILL.md files — make sure the discovery snippet is embedded in both, not just linked from one.
+- Test 9 failure on `/revise-claude-md`: description missing the legacy form — add to frontmatter `description:`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/test-agents-md-skills.sh
+git commit -m "test(agents-md-management): unit tests for skill structure and content"
+```
+
+---
+
+## Task 9: Update root README.md
+
+**Files:**
+- Modify: `README.md` (project root)
+
+The root README has a Plugins table and Installation/Setup sections. Add `agents-md-management` to each.
+
+- [ ] **Step 1: Inspect current README plugins section**
+
+```bash
+grep -n 'Plugins' README.md | head -5
+grep -n '| Plugin' README.md | head -3
+```
+
+Expected: locate the markdown table heading. Note the line numbers.
+
+- [ ] **Step 2: Read the table block**
+
+Use the line numbers from Step 1 to locate the existing plugin table. Read it to confirm structure (column count, separator style).
+
+- [ ] **Step 3: Append the new row to the Plugins table**
+
+Use the Edit tool. The exact change depends on the current table contents; the new row must follow the same format. Pattern:
+
+```diff
+ | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
++| `agents-md-management` | 0.1.0 | `agents-md-improver`, `agents-md-session-capture` |
+```
+
+- [ ] **Step 4: Update Installation section**
+
+Find the section that lists `/plugin install <name>@pgoell-claude-tools` lines. Add:
+
+```text
+/plugin install agents-md-management@pgoell-claude-tools
+```
+
+- [ ] **Step 5: Update Setup section**
+
+If the Setup section has per-plugin notes, add a one-liner like:
+
+```markdown
+### agents-md-management
+
+No setup required. Operates on local agent-instruction files only.
+```
+
+If the Setup section is structured differently, follow the existing pattern.
+
+- [ ] **Step 6: Verify**
+
+```bash
+grep -c 'agents-md-management' README.md
+```
+
+Expected: at least 2 hits (table row + install command). 3+ if a Setup blurb was added.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add agents-md-management to root README"
+```
+
+---
+
+## Task 10: Run the codex-plugin-structure test and final verification
+
+The repo has `tests/unit/test-codex-plugin-structure.sh` which validates that every plugin under `plugins/` has both `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` with the required Codex `interface` block. The new plugin must pass it.
+
+- [ ] **Step 1: Run the structure test**
+
+```bash
+bash tests/unit/test-codex-plugin-structure.sh
+```
+
+Expected: passes for `agents-md-management` (alongside the other 5 plugins).
+
+- [ ] **Step 2: If it fails, fix the relevant manifest field**
+
+Most common cause: missing `interface.displayName` or `interface.shortDescription` in `.codex-plugin/plugin.json`. Re-check Task 1 Step 3.
+
+- [ ] **Step 3: Run the new unit test**
+
+```bash
+bash tests/unit/test-agents-md-skills.sh
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Verify both marketplaces still parse and contain 6 plugins**
+
+```bash
+jq '.plugins | length' .claude-plugin/marketplace.json
+jq '.plugins | length' .agents/plugins/marketplace.json
+jq '.plugins[].name' .claude-plugin/marketplace.json
+jq '.plugins[].name' .agents/plugins/marketplace.json
+```
+
+Expected: both report 6, both lists include `agents-md-management`.
+
+- [ ] **Step 5: Verify directory tree matches the spec**
+
+```bash
+find plugins/agents-md-management -type f | sort
+```
+
+Expected output (no extras, no missing):
+
+```
+plugins/agents-md-management/.claude-plugin/plugin.json
+plugins/agents-md-management/.codex-plugin/plugin.json
+plugins/agents-md-management/LICENSE
+plugins/agents-md-management/NOTICE
+plugins/agents-md-management/README.md
+plugins/agents-md-management/skills/agents-md-improver/SKILL.md
+plugins/agents-md-management/skills/agents-md-improver/references/quality-criteria.md
+plugins/agents-md-management/skills/agents-md-improver/references/templates.md
+plugins/agents-md-management/skills/agents-md-improver/references/update-guidelines.md
+plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
+```
+
+- [ ] **Step 6: Skill-triggering smoke test (optional, requires `claude` CLI)**
+
+For each prompt file, verify the right skill triggers. This is slow (~60s per call) and requires Claude API access; skip if unavailable. The runner outputs PASS/FAIL.
+
+```bash
+PLUGIN_DIR=plugins/agents-md-management bash tests/skill-triggering/run-test.sh agents-md-improver tests/skill-triggering/prompts/agents-md-audit.txt
+PLUGIN_DIR=plugins/agents-md-management bash tests/skill-triggering/run-test.sh agents-md-improver tests/skill-triggering/prompts/agents-md-audit-agents.txt
+PLUGIN_DIR=plugins/agents-md-management bash tests/skill-triggering/run-test.sh agents-md-improver tests/skill-triggering/prompts/agents-md-global-audit.txt
+PLUGIN_DIR=plugins/agents-md-management bash tests/skill-triggering/run-test.sh agents-md-session-capture tests/skill-triggering/prompts/agents-md-session-capture.txt
+PLUGIN_DIR=plugins/agents-md-management bash tests/skill-triggering/run-test.sh agents-md-session-capture tests/skill-triggering/prompts/agents-md-session-capture-cmd.txt
+```
+
+Expected: each prints `[PASS] Skill 'X' was triggered`.
+
+If any prompt does NOT trigger the expected skill, the description field needs sharpening. Edit the relevant SKILL.md frontmatter `description:` and re-run. Re-run the unit test (Task 8) to ensure it still passes.
+
+- [ ] **Step 7: Final state check — no outstanding changes, clean working tree**
+
+```bash
+git status
+git log --oneline | head -10
+```
+
+Expected: clean tree (everything committed across Tasks 1–9), recent commits show the agents-md-management feature progression.
+
+---
+
+## Self-Review Notes
+
+Performed inline before saving the plan; no issues found:
+
+- **Spec coverage:** Every section of the spec is mapped to a task. §1 (Purpose) → Tasks 3, 4 (skill content). §2 (Scope, in + out) → Tasks 3, 4 (discovery section). §3 (Architecture) → Tasks 1, 2, 3, 4 (file creation). §4 (Discovery) → embedded in Tasks 3, 4 SKILL.md. §5 (Improver workflow) → Task 3. §6 (Session-capture workflow) → Task 4. §7 (Platform Adaptation) → Tasks 3, 4 (table). §8 (Marketplace registration) → Tasks 5, 6. §9 (Versioning, attribution, license) → Task 1 (manifests, NOTICE, LICENSE, README credit). §10 (Tests) → Tasks 7, 8, 10.
+- **Placeholder scan:** no TBD/TODO/"add appropriate handling"/"similar to". Every code block contains real content.
+- **Type consistency:** plugin name `agents-md-management`, skill names `agents-md-improver` and `agents-md-session-capture` are used consistently. Discovery glob is byte-identical between Tasks 3 and 4 (and the spec). Test assertion targets align with the strings the SKILL.md files actually contain.

--- a/docs/superpowers/specs/2026-05-04-agents-md-management-design.md
+++ b/docs/superpowers/specs/2026-05-04-agents-md-management-design.md
@@ -1,0 +1,204 @@
+# agents-md-management plugin: design spec
+
+**Date:** 2026-05-04
+**Status:** Approved, ready for implementation plan
+**Plugin:** `agents-md-management` (new)
+**Skills:** `agents-md-improver`, `agents-md-session-capture`
+
+## 1. Purpose
+
+A two-skill plugin for maintaining `AGENTS.md` and `CLAUDE.md` files (and their variants) so that host agents in any runtime have current, well-organized project context. Ports Anthropic's upstream `claude-md-management` plugin (skill + slash command) into a runtime-agnostic form that works equally in Claude Code and Codex CLI.
+
+Two distinct workflows live side by side in the plugin:
+
+* **`agents-md-improver`** is the periodic *cold audit*. Sweeps every agent-instruction file in scope, scores quality, recommends targeted edits.
+* **`agents-md-session-capture`** is the end-of-session *warm capture*. Reflects on what context was missing during the current session and proposes additions, routing each to the file at the correct scope (project, local, user-global).
+
+The skills are independent. They share the discovery glob and the reference docs but otherwise stay focused on their own job.
+
+## 2. Scope
+
+### In scope
+
+| File | Notes |
+|---|---|
+| `AGENTS.md`, `AGENTS.local.md` | Codex / agents.md spec; `AGENTS.local.md` is an emerging local-override convention |
+| `CLAUDE.md`, `CLAUDE.local.md` | Documented Claude Code variants |
+| `.claude.md`, `.claude.local.md` | Legacy lowercase variants kept by upstream's plugin |
+| `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` | User-global memory files; included in the default sweep so generalizable rules can be moved across the project/global boundary |
+
+Files at any depth in the repo are in scope (monorepos: `packages/*/AGENTS.md` etc.).
+
+`node_modules/` and `.git/` are excluded.
+
+Symlinked pairs (the common case in this repo: `CLAUDE.md` → `AGENTS.md`) are deduped via `realpath` so they are audited as one logical file. Edits target the canonical realpath.
+
+### Out of scope
+
+* `GEMINI.md` and other non-Claude/non-Codex runtime variants. Easy to add later if a need shows up.
+* Editing skill content or restructuring directories. The plugin is purely a reader/writer of memory files.
+* Networking, authentication, secrets. Pure local-filesystem operation.
+* Translation between AGENTS.md and CLAUDE.md when they have diverged. That is `runtime-bridge`'s job. This plugin operates on whatever files exist as-is.
+
+## 3. Architecture
+
+```
+plugins/agents-md-management/
+├── .claude-plugin/
+│   └── plugin.json                          # Claude Code manifest
+├── .codex-plugin/
+│   └── plugin.json                          # Codex manifest, "skills": "./skills/"
+├── README.md                                # Includes upstream credit
+├── LICENSE                                  # MIT
+└── skills/
+    ├── agents-md-improver/
+    │   ├── SKILL.md                         # ported from upstream + Platform Adaptation
+    │   └── references/
+    │       ├── quality-criteria.md          # verbatim from upstream
+    │       ├── templates.md                 # verbatim from upstream
+    │       └── update-guidelines.md         # verbatim from upstream
+    └── agents-md-session-capture/
+        └── SKILL.md                         # converted from upstream's /revise-claude-md
+```
+
+## 4. Discovery
+
+Both skills use the same discovery routine. Output is a deduped list of canonical (realpath-resolved) file paths.
+
+```bash
+{
+  find . \( \
+      -name "AGENTS.md" \
+      -o -name "AGENTS.local.md" \
+      -o -name "CLAUDE.md" \
+      -o -name "CLAUDE.local.md" \
+      -o -name ".claude.md" \
+      -o -name ".claude.local.md" \
+    \) -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+  ls ~/.claude/CLAUDE.md ~/.codex/AGENTS.md 2>/dev/null
+} | xargs -I{} realpath {} | sort -u
+```
+
+For each unique file, the host agent classifies the scope before processing:
+
+* **Project-shared:** `AGENTS.md`, `CLAUDE.md`, `.claude.md` (in repo, in git)
+* **Project-local:** `AGENTS.local.md`, `CLAUDE.local.md`, `.claude.local.md` (in repo, gitignored)
+* **User-global:** `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`
+
+The audit/capture lens shifts per scope. For project files: "is this codebase well-documented?". For the global file: "are these rules organized, non-contradictory, at the right abstraction level, and not duplicated across projects?".
+
+## 5. Skill: `agents-md-improver`
+
+Faithful port of the upstream `claude-md-improver` skill. Workflow phases unchanged from upstream:
+
+1. **Discovery** — run the glob from §4.
+2. **Quality assessment** — score each unique file against the rubric in `references/quality-criteria.md`. Six criteria (commands/workflows, architecture clarity, non-obvious patterns, conciseness, currency, actionability), letter grades A–F.
+3. **Quality report** — output the report *before* any edits, with file-by-file scores, issues, and recommended additions.
+4. **Targeted updates** — show diffs for each proposed addition, grouped by target file, each with a `Why:` line. Confirmation required before writing.
+5. **Apply** — edit each approved file via the host agent's edit tool (see Platform Adaptation, §7).
+
+Reference docs (`quality-criteria.md`, `templates.md`, `update-guidelines.md`) are imported verbatim from upstream — they describe content quality, which is runtime-agnostic.
+
+The skill body adapts the discovery section (§4), the file-types table (adds `AGENTS.md`, `AGENTS.local.md`, scope classification, dedupe-by-realpath note), and replaces "Claude auto-discovers" prose with "the host agent auto-discovers". No other content changes.
+
+## 6. Skill: `agents-md-session-capture`
+
+Replaces upstream's `/revise-claude-md` slash command. Codex has no slash commands, so a skill is the only artifact that works in both runtimes.
+
+Workflow:
+
+1. **Reflect** — what context was missing during the current session that would have helped the host agent? Bash commands used, code-style patterns followed, testing approaches that worked, environment quirks, gotchas hit.
+2. **Discover** — run the glob from §4.
+3. **Classify each learning by scope:**
+   * Project-specific (build commands, this codebase's quirks) → project-shared file
+   * Personal / not-for-team (your local override) → project-local file
+   * Generalizable / cross-project (writing style, tool preferences, system-wide rules) → user-global file
+4. **Draft additions** — concise, one line per concept. Format: `<command or pattern>` — `<brief description>`. Avoid verbose explanations and obvious info.
+5. **Show proposed diffs** — grouped by target file, each with a `Why:` line.
+6. **Apply on user approval** — file by file.
+
+Trigger phrases include "capture session learnings", "update CLAUDE.md / AGENTS.md with what we learned", "/revise-agents-md", "/revise-claude-md" (the legacy form, since users will still type it from muscle memory).
+
+## 7. Platform Adaptation
+
+Both skills include the same table near the top of `SKILL.md`:
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Find files | `Glob` / `Grep` | `shell` (`find`, `grep`) |
+| Read a file | `Read` | `shell` (`cat`) |
+| Edit a file | `Edit` | `apply_patch` / `shell` heredoc |
+| User confirmation | `AskUserQuestion` | `ask_user` / built-in approval prompt |
+| Shell commands | `Bash` | `shell` |
+
+The skill bodies refer to actions abstractly ("read the file", "apply the diff") and the host agent maps via the table.
+
+## 8. Marketplace registration
+
+**`.claude-plugin/marketplace.json`** (append to `plugins`):
+
+```json
+{
+  "name": "agents-md-management",
+  "source": "./plugins/agents-md-management",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
+  "version": "0.1.0"
+}
+```
+
+**`.agents/plugins/marketplace.json`** (append to `plugins`):
+
+```json
+{
+  "name": "agents-md-management",
+  "source": { "source": "local", "path": "./plugins/agents-md-management" },
+  "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+  "category": "Productivity",
+  "interface": {
+    "displayName": "Agents.md Management",
+    "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
+  }
+}
+```
+
+`plugins/agents-md-management/.codex-plugin/plugin.json` includes the longer interface block (`displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities: ["Interactive", "Write"]`, `defaultPrompt`, `screenshots`) per repo convention.
+
+## 9. Versioning, attribution, license
+
+* **Plugin version:** `0.1.0`. Matches `runtime-bridge`'s pattern. This is a port, not a v1 product.
+* **Author on manifests:** Pascal Kraus.
+* **Upstream credit:** README includes a credit section pointing to Anthropic's `claude-md-management` plugin and Isabella He, with a note that the reference docs (`quality-criteria.md`, `templates.md`, `update-guidelines.md`) are imported verbatim.
+* **License:** MIT, matching the rest of the repo.
+
+## 10. Tests
+
+### Skill-triggering (`tests/skill-triggering/prompts/`)
+
+* `agents-md-audit.txt` — "audit my CLAUDE.md files"
+* `agents-md-audit-agents.txt` — "check if AGENTS.md is up to date"
+* `agents-md-session-capture.txt` — "update AGENTS.md with what we learned this session"
+* `agents-md-session-capture-cmd.txt` — "/revise-agents-md"
+* `agents-md-global-audit.txt` — "audit my global ~/.claude/CLAUDE.md"
+
+### Unit (`tests/unit/test-agents-md-skills.sh`)
+
+Asserts:
+
+* Both skills load and are recognized by name
+* Descriptions mention audit/improve and session learnings respectively
+* Skill bodies mention both `AGENTS.md` and `CLAUDE.md`
+* Both skill bodies mention `realpath` (the dedup hint, embedded in the shared discovery snippet from §4)
+* Skill bodies have the Platform Adaptation table (check for the row labels)
+* Reference docs `quality-criteria.md`, `templates.md`, `update-guidelines.md` exist under `agents-md-improver/references/` and are referenced from `SKILL.md`
+
+### No integration tests
+
+Per project decision. The audit logic is inherited from upstream unchanged; integration tests would mostly re-validate that.
+
+## 11. Out-of-scope follow-ups
+
+Captured here so they don't get lost:
+
+* `GEMINI.md` and other runtime variants in the default sweep.
+* Auto-creating a missing `AGENTS.md` ↔ `CLAUDE.md` symlink when one file is present and the other isn't. That is `runtime-bridge`'s job; this plugin doesn't move into that territory.
+* A "compare global vs project rules and recommend hoisting" mode for the audit skill. Currently the skill flags scope-mismatch in prose, not as a structured action.

--- a/plugins/agents-md-management/.claude-plugin/plugin.json
+++ b/plugins/agents-md-management/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "agents-md-management",
+  "version": "0.1.0",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope.",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"]
+}

--- a/plugins/agents-md-management/.claude-plugin/plugin.json
+++ b/plugins/agents-md-management/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "agents-md-management",
   "version": "0.1.0",
   "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope.",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"]
 }

--- a/plugins/agents-md-management/.codex-plugin/plugin.json
+++ b/plugins/agents-md-management/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "agents-md-management",
+  "version": "0.1.0",
+  "description": "Audit and maintain AGENTS.md / CLAUDE.md files; capture session learnings",
+  "author": { "name": "Pascal Kraus" },
+  "license": "MIT",
+  "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agents.md Management",
+    "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings",
+    "longDescription": "Two skills for keeping agent-instruction files current. agents-md-improver runs a periodic cold audit, scoring each file against a six-criterion rubric and proposing targeted edits. agents-md-session-capture runs an end-of-session warm capture, classifying each learning by scope (project-shared, project-local, user-global) and routing edits to the right file. Discovery is symlink-aware via realpath, so paired CLAUDE.md/AGENTS.md count as one logical file. User-global memory files (~/.claude/CLAUDE.md, ~/.codex/AGENTS.md) are included in the default sweep.",
+    "developerName": "Pascal Kraus",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "defaultPrompt": [
+      "Audit my CLAUDE.md and AGENTS.md files",
+      "Update AGENTS.md with what we learned this session",
+      "Check if my agent instructions are up to date"
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/agents-md-management/.codex-plugin/plugin.json
+++ b/plugins/agents-md-management/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "agents-md-management",
   "version": "0.1.0",
   "description": "Audit and maintain AGENTS.md / CLAUDE.md files; capture session learnings",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["agents-md", "claude-md", "memory", "audit", "session-capture", "claude-code", "codex"],
   "skills": "./skills/",
@@ -10,7 +10,7 @@
     "displayName": "Agents.md Management",
     "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings",
     "longDescription": "Two skills for keeping agent-instruction files current. agents-md-improver runs a periodic cold audit, scoring each file against a six-criterion rubric and proposing targeted edits. agents-md-session-capture runs an end-of-session warm capture, classifying each learning by scope (project-shared, project-local, user-global) and routing edits to the right file. Discovery is symlink-aware via realpath, so paired CLAUDE.md/AGENTS.md count as one logical file. User-global memory files (~/.claude/CLAUDE.md, ~/.codex/AGENTS.md) are included in the default sweep.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": ["Interactive", "Read", "Write"],
     "defaultPrompt": [

--- a/plugins/agents-md-management/LICENSE
+++ b/plugins/agents-md-management/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pascal Kraus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/agents-md-management/LICENSE
+++ b/plugins/agents-md-management/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Pascal Kraus
+Copyright (c) 2026 Pascal Göllner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/plugins/agents-md-management/NOTICE
+++ b/plugins/agents-md-management/NOTICE
@@ -1,0 +1,19 @@
+agents-md-management
+Copyright 2026 Pascal Kraus
+
+This plugin contains content derived from Anthropic's claude-md-management
+plugin (https://github.com/anthropics/claude-plugins), authored by Isabella He,
+licensed under the Apache License, Version 2.0:
+
+  - skills/agents-md-improver/SKILL.md
+      (workflow phases, quality rubric structure, report format)
+  - skills/agents-md-improver/references/quality-criteria.md (verbatim)
+  - skills/agents-md-improver/references/templates.md         (verbatim)
+  - skills/agents-md-improver/references/update-guidelines.md (verbatim)
+  - skills/agents-md-session-capture/SKILL.md
+      (adapted from upstream's /revise-claude-md slash command)
+
+Apache License 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Adaptations are licensed under MIT (see LICENSE) where they qualify as
+original work; preserved upstream content remains under Apache 2.0.

--- a/plugins/agents-md-management/NOTICE
+++ b/plugins/agents-md-management/NOTICE
@@ -1,5 +1,5 @@
 agents-md-management
-Copyright 2026 Pascal Kraus
+Copyright 2026 Pascal Göllner
 
 This plugin contains content derived from Anthropic's claude-md-management
 plugin (https://github.com/anthropics/claude-plugins), authored by Isabella He,

--- a/plugins/agents-md-management/README.md
+++ b/plugins/agents-md-management/README.md
@@ -1,0 +1,37 @@
+# agents-md-management
+
+Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and their variants) so the host agent in any runtime has current, well-organized project context.
+
+Two skills:
+
+| | Purpose | Triggered by |
+|---|---|---|
+| `agents-md-improver` | Periodic cold audit against the codebase | "audit my CLAUDE.md", "check if AGENTS.md is up to date" |
+| `agents-md-session-capture` | End-of-session warm capture of learnings | "/revise-agents-md", "update AGENTS.md with what we learned this session" |
+
+Works in Claude Code and Codex CLI. Files are deduped via `realpath`, so `CLAUDE.md` symlinked to `AGENTS.md` counts as one logical file.
+
+## Files in scope
+
+- `AGENTS.md`, `AGENTS.local.md`
+- `CLAUDE.md`, `CLAUDE.local.md`
+- `.claude.md`, `.claude.local.md` (legacy lowercase from upstream)
+- `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` (user-global, included so generalizable rules can be hoisted)
+
+`GEMINI.md` and other runtime variants are out of scope.
+
+## Usage
+
+```text
+audit my CLAUDE.md files
+check if AGENTS.md is up to date
+update AGENTS.md with what we learned this session
+/revise-agents-md
+/revise-claude-md
+```
+
+## Credits
+
+Derived from Anthropic's [`claude-md-management`](https://github.com/anthropics/claude-plugins/tree/main/plugins/claude-md-management) plugin by Isabella He, licensed under Apache 2.0. The reference docs under `skills/agents-md-improver/references/` are imported verbatim. See `NOTICE` for full attribution.
+
+This plugin is licensed MIT (`LICENSE`).

--- a/plugins/agents-md-management/skills/agents-md-improver/SKILL.md
+++ b/plugins/agents-md-management/skills/agents-md-improver/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: agents-md-improver
+description: Audit and improve AGENTS.md / CLAUDE.md files (and variants like AGENTS.local.md, CLAUDE.local.md, .claude.md, .claude.local.md, plus user-global ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md) in repositories. Use when user asks to check, audit, update, improve, or fix agent-instruction files. Scans for all variants, dedupes symlinked pairs via realpath, evaluates quality against a six-criterion rubric, outputs a quality report, then makes targeted updates. Also triggers on "CLAUDE.md maintenance", "AGENTS.md audit", "project memory optimization", or "agent instructions audit".
+tools: Read, Glob, Grep, Bash, Edit
+---
+
+# Agents.md Improver
+
+Audit, evaluate, and improve agent-instruction files (AGENTS.md, CLAUDE.md, and variants) across a codebase to ensure the host agent has optimal project context.
+
+**This skill can write to agent-instruction files.** After presenting a quality report and getting user approval, it updates files with targeted improvements.
+
+## Platform Adaptation
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Find files | `Glob` / `Grep` | `shell` (`find`, `grep`) |
+| Read a file | `Read` | `shell` (`cat`) |
+| Edit a file | `Edit` | `apply_patch` / `shell` heredoc |
+| User confirmation | `AskUserQuestion` | `ask_user` / built-in approval prompt |
+| Shell commands | `Bash` | `shell` |
+
+The skill body refers to actions abstractly ("read the file", "apply the diff"). The host agent maps to its own tool inventory.
+
+## Workflow
+
+### Phase 1: Discovery
+
+Find every agent-instruction file in scope (project + user-global), dedupe symlinked pairs via `realpath`:
+
+```bash
+{
+  find . \( \
+      -name "AGENTS.md" \
+      -o -name "AGENTS.local.md" \
+      -o -name "CLAUDE.md" \
+      -o -name "CLAUDE.local.md" \
+      -o -name ".claude.md" \
+      -o -name ".claude.local.md" \
+    \) -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+  ls ~/.claude/CLAUDE.md ~/.codex/AGENTS.md 2>/dev/null
+} | xargs -I{} realpath {} | sort -u
+```
+
+**File Types & Locations:**
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| Project-shared | `./AGENTS.md`, `./CLAUDE.md`, `./.claude.md` | Primary project context, in git, shared with team |
+| Project-local | `./AGENTS.local.md`, `./CLAUDE.local.md`, `./.claude.local.md` | Personal overrides, gitignored |
+| User-global | `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` | User-wide defaults across all projects |
+| Package-specific | `./packages/*/AGENTS.md`, `./packages/*/CLAUDE.md` | Module-level context in monorepos |
+| Subdirectory | Any nested location | Feature/domain-specific context |
+
+**Note:** The host agent auto-discovers agent-instruction files in parent directories, making monorepo setups work automatically. When two paths share the same `realpath` (typical when CLAUDE.md is a symlink to AGENTS.md), audit them as one logical file and edit the canonical realpath target.
+
+### Phase 2: Quality Assessment
+
+For each unique file, evaluate against quality criteria. See [references/quality-criteria.md](references/quality-criteria.md) for detailed rubrics.
+
+**Scope-aware lens:** the assessment lens shifts per scope. For project files: "is this codebase well-documented for an agent?". For user-global files: "are these rules organized, non-contradictory, at the right abstraction level, and not duplicated across projects?".
+
+**Quick Assessment Checklist:**
+
+| Criterion | Weight | Check |
+|-----------|--------|-------|
+| Commands/workflows documented | High | Are build/test/deploy commands present? |
+| Architecture clarity | High | Can the host agent understand the codebase structure? |
+| Non-obvious patterns | Medium | Are gotchas and quirks documented? |
+| Conciseness | Medium | No verbose explanations or obvious info? |
+| Currency | High | Does it reflect current codebase state? |
+| Actionability | High | Are instructions executable, not vague? |
+
+**Quality Scores:**
+- **A (90-100)**: Comprehensive, current, actionable
+- **B (70-89)**: Good coverage, minor gaps
+- **C (50-69)**: Basic info, missing key sections
+- **D (30-49)**: Sparse or outdated
+- **F (0-29)**: Missing or severely outdated
+
+### Phase 3: Quality Report Output
+
+**ALWAYS output the quality report BEFORE making any updates.**
+
+Format:
+
+```
+## Agents.md Quality Report
+
+### Summary
+- Files found: X (Y unique after realpath dedup)
+- Average score: X/100
+- Files needing update: X
+
+### File-by-File Assessment
+
+#### 1. ./AGENTS.md (Project-shared, also reachable as ./CLAUDE.md symlink)
+**Score: XX/100 (Grade: X)**
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Commands/workflows | X/20 | ... |
+| Architecture clarity | X/20 | ... |
+| Non-obvious patterns | X/15 | ... |
+| Conciseness | X/15 | ... |
+| Currency | X/15 | ... |
+| Actionability | X/15 | ... |
+
+**Issues:**
+- [List specific problems]
+
+**Recommended additions:**
+- [List what should be added]
+
+#### 2. ./packages/api/AGENTS.md (Package-specific)
+...
+```
+
+### Phase 4: Targeted Updates
+
+After outputting the quality report, ask user for confirmation before updating.
+
+**Update Guidelines (Critical):**
+
+1. **Propose targeted additions only**: focus on genuinely useful info:
+   - Commands or workflows discovered during analysis
+   - Gotchas or non-obvious patterns found in code
+   - Package relationships that weren't clear
+   - Testing approaches that work
+   - Configuration quirks
+
+2. **Keep it minimal**: avoid:
+   - Restating what's obvious from the code
+   - Generic best practices already covered
+   - One-off fixes unlikely to recur
+   - Verbose explanations when a one-liner suffices
+
+3. **Show diffs**: for each change, show:
+   - Which file to update (use the canonical realpath)
+   - The specific addition (as a diff or quoted block)
+   - Brief explanation of why this helps future sessions
+
+**Diff Format:**
+
+````markdown
+### Update: ./AGENTS.md
+
+**Why:** Build command was missing, causing confusion about how to run the project.
+
+```diff
++ ## Quick Start
++
++ ```bash
++ npm install
++ npm run dev  # Start development server on port 3000
++ ```
+```
+````
+
+### Phase 5: Apply Updates
+
+After user approval, apply changes (see Platform Adaptation for the right edit tool). Preserve existing content structure. Edit the canonical realpath target only; symlinks update automatically.
+
+## Templates
+
+See [references/templates.md](references/templates.md) for templates by project type.
+
+## Update Guidelines Reference
+
+See [references/update-guidelines.md](references/update-guidelines.md) for full do's and don'ts.
+
+## Common Issues to Flag
+
+1. **Stale commands**: build commands that no longer work
+2. **Missing dependencies**: required tools not mentioned
+3. **Outdated architecture**: file structure that's changed
+4. **Missing environment setup**: required env vars or config
+5. **Broken test commands**: test scripts that have changed
+6. **Undocumented gotchas**: non-obvious patterns not captured
+7. **Scope mismatch**: project-specific rules in the user-global file (or vice versa)
+8. **Duplicate rules**: same rule stated in both project and user-global file
+
+## User Tips to Share
+
+When presenting recommendations, remind users:
+
+- **`#` key shortcut (Claude Code)**: during a Claude Code session, press `#` to have Claude auto-incorporate learnings into the project memory file
+- **Keep it concise**: agent-instruction files should be human-readable; dense is better than verbose
+- **Actionable commands**: all documented commands should be copy-paste ready
+- **Use `*.local.md`**: for personal preferences not shared with team (add to `.gitignore`)
+- **Global defaults**: put user-wide preferences in `~/.claude/CLAUDE.md` or `~/.codex/AGENTS.md`
+- **Symlink for cross-runtime parity**: if you use both Claude Code and Codex, symlink `CLAUDE.md` → `AGENTS.md` so a single file serves both
+
+## What Makes a Great Agent-Instruction File
+
+**Key principles:**
+- Concise and human-readable
+- Actionable commands that can be copy-pasted
+- Project-specific patterns, not generic advice
+- Non-obvious gotchas and warnings
+
+**Recommended sections** (use only what's relevant):
+- Commands (build, test, dev, lint)
+- Architecture (directory structure)
+- Key Files (entry points, config)
+- Code Style (project conventions)
+- Environment (required vars, setup)
+- Testing (commands, patterns)
+- Gotchas (quirks, common mistakes)
+- Workflow (when to do what)

--- a/plugins/agents-md-management/skills/agents-md-improver/references/quality-criteria.md
+++ b/plugins/agents-md-management/skills/agents-md-improver/references/quality-criteria.md
@@ -1,0 +1,109 @@
+# CLAUDE.md Quality Criteria
+
+## Scoring Rubric
+
+### 1. Commands/Workflows (20 points)
+
+**20 points**: All essential commands documented with context
+- Build, test, lint, deploy commands present
+- Development workflow clear
+- Common operations documented
+
+**15 points**: Most commands present, some missing context
+
+**10 points**: Basic commands only, no workflow
+
+**5 points**: Few commands, many missing
+
+**0 points**: No commands documented
+
+### 2. Architecture Clarity (20 points)
+
+**20 points**: Clear codebase map
+- Key directories explained
+- Module relationships documented
+- Entry points identified
+- Data flow described where relevant
+
+**15 points**: Good structure overview, minor gaps
+
+**10 points**: Basic directory listing only
+
+**5 points**: Vague or incomplete
+
+**0 points**: No architecture info
+
+### 3. Non-Obvious Patterns (15 points)
+
+**15 points**: Gotchas and quirks captured
+- Known issues documented
+- Workarounds explained
+- Edge cases noted
+- "Why we do it this way" for unusual patterns
+
+**10 points**: Some patterns documented
+
+**5 points**: Minimal pattern documentation
+
+**0 points**: No patterns or gotchas
+
+### 4. Conciseness (15 points)
+
+**15 points**: Dense, valuable content
+- No filler or obvious info
+- Each line adds value
+- No redundancy with code comments
+
+**10 points**: Mostly concise, some padding
+
+**5 points**: Verbose in places
+
+**0 points**: Mostly filler or restates obvious code
+
+### 5. Currency (15 points)
+
+**15 points**: Reflects current codebase
+- Commands work as documented
+- File references accurate
+- Tech stack current
+
+**10 points**: Mostly current, minor staleness
+
+**5 points**: Several outdated references
+
+**0 points**: Severely outdated
+
+### 6. Actionability (15 points)
+
+**15 points**: Instructions are executable
+- Commands can be copy-pasted
+- Steps are concrete
+- Paths are real
+
+**10 points**: Mostly actionable
+
+**5 points**: Some vague instructions
+
+**0 points**: Vague or theoretical
+
+## Assessment Process
+
+1. Read the CLAUDE.md file completely
+2. Cross-reference with actual codebase:
+   - Run documented commands (mentally or actually)
+   - Check if referenced files exist
+   - Verify architecture descriptions
+3. Score each criterion
+4. Calculate total and assign grade
+5. List specific issues found
+6. Propose concrete improvements
+
+## Red Flags
+
+- Commands that would fail (wrong paths, missing deps)
+- References to deleted files/folders
+- Outdated tech versions
+- Copy-paste from templates without customization
+- Generic advice not specific to the project
+- "TODO" items never completed
+- Duplicate info across multiple CLAUDE.md files

--- a/plugins/agents-md-management/skills/agents-md-improver/references/templates.md
+++ b/plugins/agents-md-management/skills/agents-md-improver/references/templates.md
@@ -1,0 +1,253 @@
+# CLAUDE.md Templates
+
+## Key Principles
+
+- **Concise**: Dense, human-readable content; one line per concept when possible
+- **Actionable**: Commands should be copy-paste ready
+- **Project-specific**: Document patterns unique to this project, not generic advice
+- **Current**: All info should reflect actual codebase state
+
+---
+
+## Recommended Sections
+
+Use only the sections relevant to the project. Not all sections are needed.
+
+### Commands
+
+Document the essential commands for working with the project.
+
+```markdown
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `<install command>` | Install dependencies |
+| `<dev command>` | Start development server |
+| `<build command>` | Production build |
+| `<test command>` | Run tests |
+| `<lint command>` | Lint/format code |
+```
+
+### Architecture
+
+Describe the project structure so Claude understands where things live.
+
+```markdown
+## Architecture
+
+```
+<root>/
+  <dir>/    # <purpose>
+  <dir>/    # <purpose>
+  <dir>/    # <purpose>
+```
+```
+
+### Key Files
+
+List important files that Claude should know about.
+
+```markdown
+## Key Files
+
+- `<path>` - <purpose>
+- `<path>` - <purpose>
+```
+
+### Code Style
+
+Document project-specific coding conventions.
+
+```markdown
+## Code Style
+
+- <convention>
+- <convention>
+- <preference over alternative>
+```
+
+### Environment
+
+Document required environment variables and setup.
+
+```markdown
+## Environment
+
+Required:
+- `<VAR_NAME>` - <purpose>
+- `<VAR_NAME>` - <purpose>
+
+Setup:
+- <setup step>
+```
+
+### Testing
+
+Document testing approach and commands.
+
+```markdown
+## Testing
+
+- `<test command>` - <what it tests>
+- <testing convention or pattern>
+```
+
+### Gotchas
+
+Document non-obvious patterns, quirks, and warnings.
+
+```markdown
+## Gotchas
+
+- <non-obvious thing that causes issues>
+- <ordering dependency or prerequisite>
+- <common mistake to avoid>
+```
+
+### Workflow
+
+Document development workflow patterns.
+
+```markdown
+## Workflow
+
+- <when to do X>
+- <preferred approach for Y>
+```
+
+---
+
+## Template: Project Root (Minimal)
+
+```markdown
+# <Project Name>
+
+<One-line description>
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `<command>` | <description> |
+
+## Architecture
+
+```
+<structure>
+```
+
+## Gotchas
+
+- <gotcha>
+```
+
+---
+
+## Template: Project Root (Comprehensive)
+
+```markdown
+# <Project Name>
+
+<One-line description>
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `<command>` | <description> |
+
+## Architecture
+
+```
+<structure with descriptions>
+```
+
+## Key Files
+
+- `<path>` - <purpose>
+
+## Code Style
+
+- <convention>
+
+## Environment
+
+- `<VAR>` - <purpose>
+
+## Testing
+
+- `<command>` - <scope>
+
+## Gotchas
+
+- <gotcha>
+```
+
+---
+
+## Template: Package/Module
+
+For packages within a monorepo or distinct modules.
+
+```markdown
+# <Package Name>
+
+<Purpose of this package>
+
+## Usage
+
+```
+<import/usage example>
+```
+
+## Key Exports
+
+- `<export>` - <purpose>
+
+## Dependencies
+
+- `<dependency>` - <why needed>
+
+## Notes
+
+- <important note>
+```
+
+---
+
+## Template: Monorepo Root
+
+```markdown
+# <Monorepo Name>
+
+<Description>
+
+## Packages
+
+| Package | Description | Path |
+|---------|-------------|------|
+| `<name>` | <purpose> | `<path>` |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `<command>` | <description> |
+
+## Cross-Package Patterns
+
+- <shared pattern>
+- <generation/sync pattern>
+```
+
+---
+
+## Update Principles
+
+When updating any CLAUDE.md:
+
+1. **Be specific**: Use actual file paths, real commands from this project
+2. **Be current**: Verify info against the actual codebase
+3. **Be brief**: One line per concept when possible
+4. **Be useful**: Would this help a new Claude session understand the project?

--- a/plugins/agents-md-management/skills/agents-md-improver/references/update-guidelines.md
+++ b/plugins/agents-md-management/skills/agents-md-improver/references/update-guidelines.md
@@ -1,0 +1,150 @@
+# CLAUDE.md Update Guidelines
+
+## Core Principle
+
+Only add information that will genuinely help future Claude sessions. The context window is precious - every line must earn its place.
+
+## What TO Add
+
+### 1. Commands/Workflows Discovered
+
+```markdown
+## Build
+
+`npm run build:prod` - Full production build with optimization
+`npm run build:dev` - Fast dev build (no minification)
+```
+
+Why: Saves future sessions from discovering these again.
+
+### 2. Gotchas and Non-Obvious Patterns
+
+```markdown
+## Gotchas
+
+- Tests must run sequentially (`--runInBand`) due to shared DB state
+- `yarn.lock` is authoritative; delete `node_modules` if deps mismatch
+```
+
+Why: Prevents repeating debugging sessions.
+
+### 3. Package Relationships
+
+```markdown
+## Dependencies
+
+The `auth` module depends on `crypto` being initialized first.
+Import order matters in `src/bootstrap.ts`.
+```
+
+Why: Architecture knowledge that isn't obvious from code.
+
+### 4. Testing Approaches That Worked
+
+```markdown
+## Testing
+
+For API endpoints: Use `supertest` with the test helper in `tests/setup.ts`
+Mocking: Factory functions in `tests/factories/` (not inline mocks)
+```
+
+Why: Establishes patterns that work.
+
+### 5. Configuration Quirks
+
+```markdown
+## Config
+
+- `NEXT_PUBLIC_*` vars must be set at build time, not runtime
+- Redis connection requires `?family=0` suffix for IPv6
+```
+
+Why: Environment-specific knowledge.
+
+## What NOT to Add
+
+### 1. Obvious Code Info
+
+Bad:
+```markdown
+The `UserService` class handles user operations.
+```
+
+The class name already tells us this.
+
+### 2. Generic Best Practices
+
+Bad:
+```markdown
+Always write tests for new features.
+Use meaningful variable names.
+```
+
+This is universal advice, not project-specific.
+
+### 3. One-Off Fixes
+
+Bad:
+```markdown
+We fixed a bug in commit abc123 where the login button didn't work.
+```
+
+Won't recur; clutters the file.
+
+### 4. Verbose Explanations
+
+Bad:
+```markdown
+The authentication system uses JWT tokens. JWT (JSON Web Tokens) are
+an open standard (RFC 7519) that defines a compact and self-contained
+way for securely transmitting information between parties as a JSON
+object. In our implementation, we use the HS256 algorithm which...
+```
+
+Good:
+```markdown
+Auth: JWT with HS256, tokens in `Authorization: Bearer <token>` header.
+```
+
+## Diff Format for Updates
+
+For each suggested change:
+
+### 1. Identify the File
+
+```
+File: ./CLAUDE.md
+Section: Commands (new section after ## Architecture)
+```
+
+### 2. Show the Change
+
+```diff
+ ## Architecture
+ ...
+
++## Commands
++
++| Command | Purpose |
++|---------|---------|
++| `npm run dev` | Dev server with HMR |
++| `npm run build` | Production build |
++| `npm test` | Run test suite |
+```
+
+### 3. Explain Why
+
+> **Why this helps:** The build commands weren't documented, causing
+> confusion about how to run the project. This saves future sessions
+> from needing to inspect `package.json`.
+
+## Validation Checklist
+
+Before finalizing an update, verify:
+
+- [ ] Each addition is project-specific
+- [ ] No generic advice or obvious info
+- [ ] Commands are tested and work
+- [ ] File paths are accurate
+- [ ] Would a new Claude session find this helpful?
+- [ ] Is this the most concise way to express the info?

--- a/plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
+++ b/plugins/agents-md-management/skills/agents-md-session-capture/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: agents-md-session-capture
+description: Capture learnings from the current session and update AGENTS.md / CLAUDE.md (and variants, including user-global ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md) with context that would help future sessions. Use when the user wants to "update CLAUDE.md with what we learned", "capture session learnings", "revise AGENTS.md", or types "/revise-agents-md" or "/revise-claude-md". Routes each learning to the right file by scope: project-specific learnings to AGENTS.md/CLAUDE.md, personal overrides to *.local.md, generalizable rules to the user-global file.
+tools: Read, Glob, Grep, Bash, Edit
+---
+
+# Agents.md Session Capture
+
+Review the current session for context that was missing and would have helped the host agent. Propose targeted additions to the right agent-instruction file by scope.
+
+## Platform Adaptation
+
+| Capability | Claude Code | Codex |
+|---|---|---|
+| Find files | `Glob` / `Grep` | `shell` (`find`, `grep`) |
+| Read a file | `Read` | `shell` (`cat`) |
+| Edit a file | `Edit` | `apply_patch` / `shell` heredoc |
+| User confirmation | `AskUserQuestion` | `ask_user` / built-in approval prompt |
+| Shell commands | `Bash` | `shell` |
+
+The skill body refers to actions abstractly. The host agent maps to its own tool inventory.
+
+## Step 1: Reflect
+
+What context was missing during this session that would have helped the host agent?
+
+- Bash commands that were used or discovered
+- Code style patterns followed
+- Testing approaches that worked
+- Environment / configuration quirks
+- Warnings or gotchas encountered
+- Tool preferences (e.g. "always use ripgrep over grep here")
+
+## Step 2: Discover candidate files
+
+Find every agent-instruction file in scope (project + user-global), dedupe symlinked pairs via `realpath`:
+
+```bash
+{
+  find . \( \
+      -name "AGENTS.md" \
+      -o -name "AGENTS.local.md" \
+      -o -name "CLAUDE.md" \
+      -o -name "CLAUDE.local.md" \
+      -o -name ".claude.md" \
+      -o -name ".claude.local.md" \
+    \) -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null
+  ls ~/.claude/CLAUDE.md ~/.codex/AGENTS.md 2>/dev/null
+} | xargs -I{} realpath {} | sort -u
+```
+
+When two paths share the same `realpath`, treat them as one logical file. Edits target the canonical realpath.
+
+## Step 3: Classify each learning by scope
+
+Decide where each addition belongs before drafting it:
+
+| Scope | Target file | Examples |
+|---|---|---|
+| Project-shared | `AGENTS.md` / `CLAUDE.md` (canonical) | Build commands, this codebase's quirks, team-wide conventions |
+| Project-local | `AGENTS.local.md` / `CLAUDE.local.md` | Your personal overrides for this project, not for the team |
+| User-global | `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` | Cross-project rules: writing style, tool preferences, system-wide preferences |
+
+If a learning is generic enough to apply to other projects, route it to the user-global file rather than this project's AGENTS.md. Avoid duplication: if a rule already exists in the user-global file, don't restate it project-locally.
+
+## Step 4: Draft additions
+
+**Keep it concise**, one line per concept. Agent-instruction files are part of the prompt, so brevity matters.
+
+Format: `<command or pattern>`, `<brief description>`
+
+Avoid:
+- Verbose explanations
+- Obvious information
+- One-off fixes unlikely to recur
+
+## Step 5: Show proposed changes
+
+For each addition:
+
+````markdown
+### Update: ./AGENTS.md
+
+**Why:** [one-line reason]
+
+```diff
++ [the addition; keep it brief]
+```
+````
+
+Group by target file. Show all proposed edits to one file together.
+
+## Step 6: Apply with approval
+
+Ask if the user wants to apply the changes. Only edit files they approve. Use the right edit tool per Platform Adaptation. Edit the canonical realpath target only; symlinks update automatically.

--- a/plugins/atlassian/.claude-plugin/plugin.json
+++ b/plugins/atlassian/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "atlassian",
   "description": "Jira and Confluence skills for the Atlassian suite — search, create, update, and manage work items and pages",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": ["jira", "confluence", "atlassian"]

--- a/plugins/atlassian/.codex-plugin/plugin.json
+++ b/plugins/atlassian/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Jira and Confluence skills for Atlassian Cloud.",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": [
@@ -16,7 +16,7 @@
     "displayName": "Atlassian",
     "shortDescription": "Use Jira and Confluence from agent workflows",
     "longDescription": "Use Atlassian skills to search Jira issues, create and update tickets, transition work items, search Confluence, read documentation, and create or update pages.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": [
       "Interactive",

--- a/plugins/google-workspace/.claude-plugin/plugin.json
+++ b/plugins/google-workspace/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "google-workspace",
   "description": "Gmail and Calendar skills for Google Workspace via the gws CLI",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": ["google", "workspace", "gmail", "calendar", "gws"]

--- a/plugins/google-workspace/.codex-plugin/plugin.json
+++ b/plugins/google-workspace/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gmail and Calendar skills for Google Workspace via the gws CLI.",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": [
@@ -18,7 +18,7 @@
     "displayName": "Google Workspace",
     "shortDescription": "Use Gmail and Calendar through gws",
     "longDescription": "Use Google Workspace skills to triage Gmail, search and read messages, send mail, view calendar agendas, create events, and check availability through the gws CLI.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": [
       "Interactive",

--- a/plugins/research/.claude-plugin/plugin.json
+++ b/plugins/research/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "research",
   "version": "2.0.0",
   "description": "Orchestrator-driven deep research: parallel cluster researchers, unbounded review loops, synthesis and writer split",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["research", "deep-research", "web-research", "report", "citations", "multi-agent", "orchestrator"]
 }

--- a/plugins/research/.codex-plugin/plugin.json
+++ b/plugins/research/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Orchestrator driven deep research with synthesis and report writing.",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": [
@@ -20,7 +20,7 @@
     "displayName": "Research",
     "shortDescription": "Plan, research, synthesize, and write reports",
     "longDescription": "Use the research skill for deep dives that need source gathering, clustered investigation, synthesis review, writer review, and a polished report artifact.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": [
       "Interactive",

--- a/plugins/runtime-bridge/.claude-plugin/plugin.json
+++ b/plugins/runtime-bridge/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "runtime-bridge",
   "version": "0.1.0",
   "description": "Bidirectionally align a project's Claude Code and Codex CLI configuration: memory files, subagents, hooks, settings",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["claude-code", "codex", "agents-md", "claude-md", "runtime", "interop", "porting", "agents", "skills"]
 }

--- a/plugins/runtime-bridge/.codex-plugin/plugin.json
+++ b/plugins/runtime-bridge/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "runtime-bridge",
   "version": "0.1.0",
   "description": "Bidirectionally align a project's Claude Code and Codex CLI configuration",
-  "author": { "name": "Pascal Kraus" },
+  "author": { "name": "Pascal Göllner" },
   "license": "MIT",
   "keywords": ["claude-code", "codex", "agents-md", "claude-md", "runtime", "interop", "porting", "agents", "skills"],
   "skills": "./skills/",
@@ -10,7 +10,7 @@
     "displayName": "Runtime Bridge",
     "shortDescription": "Make a project work with both Claude Code and Codex CLI",
     "longDescription": "Detects what runtime artifacts a project has (CLAUDE.md or AGENTS.md, .claude/, .codex/) and produces the missing side. Hierarchical memory file mirroring via symlinks. Mechanical translation of subagents and hooks. Lossy translation of settings keys with defensible analogues. Source-sniff plugin report with no migration. Scout/apply/reviewer subagent pipeline with no fixed loop cap.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": ["Interactive", "Read", "Write"],
     "defaultPrompt": [

--- a/plugins/writing/.claude-plugin/plugin.json
+++ b/plugins/writing/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.6.0",
   "description": "Multi-phase writing pipeline with panel-of-critics review for blog posts, essays, talks, and longer-form prose. Also ships a dedicated Pyramid Principle skill for memos, recommendations, and analytical documents.",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": ["writing", "blog", "essay", "drafting", "editing", "voice", "pyramid", "minto", "mece", "scqa", "memo", "briefing", "announcement"]

--- a/plugins/writing/.codex-plugin/plugin.json
+++ b/plugins/writing/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.6.0",
   "description": "Writing, pyramid structure, and technical documentation skills.",
   "author": {
-    "name": "Pascal Kraus"
+    "name": "Pascal Göllner"
   },
   "license": "MIT",
   "keywords": [
@@ -27,7 +27,7 @@
     "displayName": "Writing",
     "shortDescription": "Draft, structure, review, and finish prose",
     "longDescription": "Use the writing skills for long form prose, Pyramid Principle outlines, analytical memos, and Diataxis aware technical documentation with review and finishing passes.",
-    "developerName": "Pascal Kraus",
+    "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": [
       "Interactive",

--- a/tests/skill-triggering/prompts/agents-md-audit-agents.txt
+++ b/tests/skill-triggering/prompts/agents-md-audit-agents.txt
@@ -1,0 +1,1 @@
+Check if my AGENTS.md is up to date with the current codebase.

--- a/tests/skill-triggering/prompts/agents-md-audit.txt
+++ b/tests/skill-triggering/prompts/agents-md-audit.txt
@@ -1,0 +1,1 @@
+Audit my CLAUDE.md files and tell me where the gaps are.

--- a/tests/skill-triggering/prompts/agents-md-global-audit.txt
+++ b/tests/skill-triggering/prompts/agents-md-global-audit.txt
@@ -1,0 +1,1 @@
+Audit my global ~/.claude/CLAUDE.md and let me know if any rules belong in a project file instead.

--- a/tests/skill-triggering/prompts/agents-md-session-capture-cmd.txt
+++ b/tests/skill-triggering/prompts/agents-md-session-capture-cmd.txt
@@ -1,0 +1,1 @@
+/revise-agents-md

--- a/tests/skill-triggering/prompts/agents-md-session-capture.txt
+++ b/tests/skill-triggering/prompts/agents-md-session-capture.txt
@@ -1,0 +1,1 @@
+Update AGENTS.md with what we learned during this session.

--- a/tests/unit/test-agents-md-skills.sh
+++ b/tests/unit/test-agents-md-skills.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Test: agents-md-improver and agents-md-session-capture skills
+# Verifies the skills load, mention both AGENTS.md and CLAUDE.md, include
+# realpath dedup, the Platform Adaptation table, and reference docs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)/plugins/agents-md-management"
+
+echo "=== Test: agents-md-management plugin structure ==="
+echo ""
+
+# Test 1: Plugin manifest files exist and parse
+echo "Test 1: Plugin manifests exist and parse..."
+if [ -f "$PLUGIN_ROOT/.claude-plugin/plugin.json" ] \
+   && jq empty "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null; then
+    echo "  [PASS] .claude-plugin/plugin.json exists and parses"
+else
+    echo "  [FAIL] .claude-plugin/plugin.json missing or malformed"
+    exit 1
+fi
+if [ -f "$PLUGIN_ROOT/.codex-plugin/plugin.json" ] \
+   && jq empty "$PLUGIN_ROOT/.codex-plugin/plugin.json" 2>/dev/null; then
+    echo "  [PASS] .codex-plugin/plugin.json exists and parses"
+else
+    echo "  [FAIL] .codex-plugin/plugin.json missing or malformed"
+    exit 1
+fi
+echo ""
+
+# Test 2: Both skills' SKILL.md files exist
+echo "Test 2: Skill files exist..."
+for skill in agents-md-improver agents-md-session-capture; do
+    if [ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]; then
+        echo "  [PASS] skills/$skill/SKILL.md exists"
+    else
+        echo "  [FAIL] skills/$skill/SKILL.md missing"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 3: Reference docs exist and are non-empty
+echo "Test 3: Reference docs exist..."
+for ref in quality-criteria.md templates.md update-guidelines.md; do
+    f="$PLUGIN_ROOT/skills/agents-md-improver/references/$ref"
+    if [ -s "$f" ]; then
+        echo "  [PASS] references/$ref exists"
+    else
+        echo "  [FAIL] references/$ref missing or empty"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 4: Both skill bodies mention AGENTS.md and CLAUDE.md
+echo "Test 4: Both skill bodies mention AGENTS.md and CLAUDE.md..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q 'AGENTS\.md' && echo "$body" | grep -q 'CLAUDE\.md'; then
+        echo "  [PASS] $skill mentions both"
+    else
+        echo "  [FAIL] $skill missing one of AGENTS.md / CLAUDE.md"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 5: Both skill bodies mention realpath (dedup hint, embedded in shared discovery snippet)
+echo "Test 5: Both skill bodies mention realpath..."
+for skill in agents-md-improver agents-md-session-capture; do
+    if grep -q 'realpath' "$PLUGIN_ROOT/skills/$skill/SKILL.md"; then
+        echo "  [PASS] $skill mentions realpath"
+    else
+        echo "  [FAIL] $skill missing realpath dedup snippet"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 6: Both skill bodies include Platform Adaptation table
+echo "Test 6: Both skill bodies have Platform Adaptation table..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q '## Platform Adaptation' \
+       && echo "$body" | grep -q 'Claude Code' \
+       && echo "$body" | grep -q 'Codex'; then
+        echo "  [PASS] $skill has Platform Adaptation table"
+    else
+        echo "  [FAIL] $skill missing Platform Adaptation table"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 7: agents-md-improver SKILL.md references the three reference docs by name
+echo "Test 7: agents-md-improver references all three docs..."
+body="$(cat "$PLUGIN_ROOT/skills/agents-md-improver/SKILL.md")"
+for ref in quality-criteria.md templates.md update-guidelines.md; do
+    if echo "$body" | grep -q "references/$ref"; then
+        echo "  [PASS] references $ref"
+    else
+        echo "  [FAIL] missing reference to $ref"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 8: User-global memory files mentioned in both skill bodies
+echo "Test 8: User-global files mentioned in both skill bodies..."
+for skill in agents-md-improver agents-md-session-capture; do
+    body="$(cat "$PLUGIN_ROOT/skills/$skill/SKILL.md")"
+    if echo "$body" | grep -q '~/.claude/CLAUDE.md' \
+       && echo "$body" | grep -q '~/.codex/AGENTS.md'; then
+        echo "  [PASS] $skill includes both user-global paths"
+    else
+        echo "  [FAIL] $skill missing one or both user-global paths"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 9: Skill descriptions trigger on the right phrases
+echo "Test 9: Description fields mention key trigger phrases..."
+improver_body="$(cat "$PLUGIN_ROOT/skills/agents-md-improver/SKILL.md")"
+capture_body="$(cat "$PLUGIN_ROOT/skills/agents-md-session-capture/SKILL.md")"
+
+improver_desc=$(echo "$improver_body" | awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag')
+capture_desc=$(echo "$capture_body" | awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag')
+
+if echo "$improver_desc" | grep -qiE 'audit|improve|fix'; then
+    echo "  [PASS] improver description mentions audit/improve/fix"
+else
+    echo "  [FAIL] improver description missing audit/improve/fix"
+    exit 1
+fi
+
+if echo "$capture_desc" | grep -qiE 'session|learned|capture|revise'; then
+    echo "  [PASS] capture description mentions session/learned/capture/revise"
+else
+    echo "  [FAIL] capture description missing session/learned/capture/revise"
+    exit 1
+fi
+
+if echo "$capture_desc" | grep -q '/revise-claude-md' \
+   && echo "$capture_desc" | grep -q '/revise-agents-md'; then
+    echo "  [PASS] capture description mentions both legacy and new slash forms"
+else
+    echo "  [FAIL] capture description missing one of the slash forms"
+    exit 1
+fi
+echo ""
+
+echo "=== Tests complete ==="

--- a/tests/unit/test-codex-plugin-structure.sh
+++ b/tests/unit/test-codex-plugin-structure.sh
@@ -18,9 +18,9 @@ marketplace_name="$(jq -r '.name' "$MARKETPLACE")"
 [ "$marketplace_name" = "pgoell-claude-tools" ] || fail "Unexpected marketplace name: $marketplace_name"
 
 plugin_count="$(jq '.plugins | length' "$MARKETPLACE")"
-[ "$plugin_count" -eq 5 ] || fail "Expected 5 Codex marketplace plugins, got $plugin_count"
+[ "$plugin_count" -eq 6 ] || fail "Expected 6 Codex marketplace plugins, got $plugin_count"
 
-for plugin in atlassian google-workspace research writing runtime-bridge; do
+for plugin in atlassian google-workspace research writing runtime-bridge agents-md-management; do
     plugin_dir="$REPO_ROOT/plugins/$plugin"
     manifest="$plugin_dir/.codex-plugin/plugin.json"
 


### PR DESCRIPTION
## Summary

- New plugin `agents-md-management` with two runtime-agnostic skills derived from Anthropic's `claude-md-management` plugin (Isabella He, Apache 2.0).
- `agents-md-improver` (cold audit) scores agent-instruction files against a six-criterion rubric and proposes targeted edits. `agents-md-session-capture` (warm capture, replaces upstream's `/revise-claude-md` slash command) reflects on session learnings and routes each addition by scope.
- Symlink-aware via `realpath`: paired `CLAUDE.md` → `AGENTS.md` count as one logical file. User-global memory files (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) are included by default so generalizable rules can be hoisted across the project/global boundary.

## Files in scope

`AGENTS.md`, `AGENTS.local.md`, `CLAUDE.md`, `CLAUDE.local.md`, `.claude.md`, `.claude.local.md`, plus user-global `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`. `GEMINI.md` and other variants are out of scope.

## Design and plan

- Spec: `docs/superpowers/specs/2026-05-04-agents-md-management-design.md`
- Plan: `docs/superpowers/plans/2026-05-04-agents-md-management.md`

## Licensing

LICENSE is MIT for adaptations. NOTICE attributes the verbatim-imported reference docs (`quality-criteria.md`, `templates.md`, `update-guidelines.md`) and adapted SKILL.md files to upstream Apache 2.0.

## Test plan

- [ ] `bash tests/unit/test-codex-plugin-structure.sh` (now expects 6 plugins, includes `agents-md-management`)
- [ ] `bash tests/unit/test-agents-md-skills.sh` (9 structural assertions, 22 PASSes)
- [ ] Optional skill-triggering smoke tests (5 prompts under `tests/skill-triggering/prompts/agents-md-*.txt`)
- [ ] `jq empty` parses both marketplace files; `.plugins | length` is 6 in each
- [ ] In a Claude Code session: trigger via "audit my CLAUDE.md files" → expect `agents-md-improver` to fire
- [ ] In a Claude Code session: trigger via `/revise-agents-md` → expect `agents-md-session-capture` to fire