### PR TITLE
feat(workbench): port brainstorming skill from superpowers as fork-as-you-touch starter

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -99,6 +99,22 @@
         "displayName": "Agents.md Management",
         "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
       }
+    },
+    {
+      "name": "workbench",
+      "source": {
+        "source": "local",
+        "path": "./plugins/workbench"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Workbench",
+        "shortDescription": "Personal forks of skills Pascal uses regularly"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,12 @@
       "source": "./plugins/agents-md-management",
       "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
       "version": "0.1.0"
+    },
+    {
+      "name": "workbench",
+      "source": "./plugins/workbench",
+      "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+      "version": "0.1.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ tests/
 | `writing` | 1.6.0 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agents-md-management` | 0.1.0 | `agents-md-improver`, `agents-md-session-capture` |
+| `workbench` | 0.1.0 | `brainstorming`, `using-workbench` |
 
 ## How to Develop a New Skill
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ codex
 /plugins
 ```
 
-In the picker, install `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`, and `agents-md-management`.
+In the picker, install `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`, `agents-md-management`, and `workbench`.
 
 `codex plugin marketplace add` accepts `owner/repo[@ref]`, an HTTPS or SSH Git URL, or a local marketplace root directory. The marketplace file lives at `.agents/plugins/marketplace.json` and the per-plugin Codex manifests live at `plugins/<plugin>/.codex-plugin/plugin.json`. Both reuse the same `plugins/<plugin>/skills/` directories as Claude Code, single sourced.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `claude-codex-bridge` | runtime-bridge | Align Claude Code and Codex artifacts in a project |
 | `agents-md-improver` | agents-md-management | Audit AGENTS.md / CLAUDE.md across project and user-global scopes; propose targeted edits |
 | `agents-md-session-capture` | agents-md-management | Capture session learnings into AGENTS.md / CLAUDE.md (or `*.local.md`, or user-global) by scope |
+| `brainstorming` | workbench | Design dialogue that turns ideas into specs, with a browser-based visual companion |
+| `using-workbench` | workbench | Meta-skill announcing Workbench skills; defers core meta-rules to upstream using-superpowers |
 
 ## Plugins
 
@@ -69,6 +71,14 @@ Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and variants like `AGENTS.lo
 - `/pgoell-claude-tools:agents-md-improver`: Periodic cold audit. Scores each file against a six-criterion rubric, outputs a quality report, then proposes targeted edits with confirmation.
 - `/pgoell-claude-tools:agents-md-session-capture`: End-of-session warm capture. Reflects on what context was missing, classifies each learning by scope (project-shared, project-local, user-global), and routes additions to the right file. Triggers on `/revise-agents-md` or `/revise-claude-md`.
 
+### workbench
+
+Personal fork-as-you-touch skill collection. Today: brainstorming (a design dialogue that turns ideas into specs, with a browser-based visual companion) and a trimmed meta-skill that layers on top of upstream `superpowers:using-superpowers`. More skills will be added as Pascal commits to owning them.
+
+**Skills:**
+- `/pgoell-claude-tools:brainstorming`: Design dialogue from idea to spec, with a visual-companion mode
+- `/pgoell-claude-tools:using-workbench`: Meta-skill announcing Workbench skills, defers core meta-rules to upstream
+
 ## Installation
 
 ### Claude Code
@@ -81,6 +91,7 @@ Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and variants like `AGENTS.lo
 /plugin install writing@pgoell-claude-tools
 /plugin install runtime-bridge@pgoell-claude-tools
 /plugin install agents-md-management@pgoell-claude-tools
+/plugin install workbench@pgoell-claude-tools
 ```
 
 ### Codex

--- a/docs/workbench/plans/2026-05-04-workbench-brainstorming-port.md
+++ b/docs/workbench/plans/2026-05-04-workbench-brainstorming-port.md
@@ -1,0 +1,1156 @@
+# Workbench plugin: brainstorming port implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the initial `workbench` plugin in `pgoell-claude-tools` with two ported skills (`brainstorming`, `using-workbench`), full Claude Code + Codex parity, dual-runtime SessionStart hook, license attribution to upstream `superpowers` v5.0.7, and marketplace registration in both registries.
+
+**Architecture:** Fork-as-you-touch port from upstream `superpowers` plugin (cached at `/home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/`). Brainstorming files are copied verbatim with surgical rebrand edits documented in the spec. `using-workbench` is freshly authored as a trimmed companion meta-skill that defers most rules to upstream `using-superpowers`. Hook config is duplicated to support Claude Code (`hooks/hooks.json`, uses `${CLAUDE_PLUGIN_ROOT}`) and Codex (`hooks.json` at plugin root, plugin-root-relative path) per the figma plugin precedent. Marketplace entries follow existing patterns in `.claude-plugin/marketplace.json` (Claude) and `.agents/plugins/marketplace.json` (Codex with `interface` block).
+
+**Tech Stack:** Bash (hook scripts, test runners), JSON (manifests, hook configs, marketplace registries), Markdown (skills, references, docs). No build step. No package dependencies.
+
+**Worktree:** This plan executes in `.worktrees/workbench` on branch `feat/workbench`. The spec doc `docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md` is already in the worktree as untracked content (carried over from main).
+
+**Reference paths used throughout:**
+- Upstream cache: `/home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/`
+- Worktree root: `/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/`
+- Spec: `docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md` (worktree-relative)
+
+---
+
+## Task 1: Add design spec and implementation plan to feature branch
+
+**Files:**
+- Add: `docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md`
+- Add: `docs/workbench/plans/2026-05-04-workbench-brainstorming-port.md`
+
+- [ ] **Step 1: Verify both files are present in worktree**
+
+```bash
+ls -la /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/docs/workbench/specs/
+ls -la /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/docs/workbench/plans/
+```
+
+Expected: spec file and plan file both listed (each with the `2026-05-04-...` prefix).
+
+- [ ] **Step 2: Stage the spec and plan together**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench && git add docs/workbench/specs/ docs/workbench/plans/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench commit -m "docs(workbench): add brainstorming port design spec and implementation plan"
+```
+
+- [ ] **Step 4: Verify commit landed**
+
+```bash
+git -C /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench log --oneline -1
+```
+
+Expected: most recent line shows the new commit message.
+
+---
+
+## Task 2: Scaffold workbench plugin (directories, manifests, attribution)
+
+**Files:**
+- Create: `plugins/workbench/.claude-plugin/plugin.json`
+- Create: `plugins/workbench/.codex-plugin/plugin.json`
+- Create: `plugins/workbench/LICENSE`
+- Create: `plugins/workbench/NOTICE`
+- Create: `plugins/workbench/README.md`
+- Create directories: `plugins/workbench/{hooks,skills/{using-workbench/references,brainstorming/scripts}}`
+
+- [ ] **Step 1: Create directory tree**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+mkdir -p plugins/workbench/.claude-plugin
+mkdir -p plugins/workbench/.codex-plugin
+mkdir -p plugins/workbench/hooks
+mkdir -p plugins/workbench/skills/using-workbench/references
+mkdir -p plugins/workbench/skills/brainstorming/scripts
+```
+
+- [ ] **Step 2: Write `.claude-plugin/plugin.json`**
+
+Path: `plugins/workbench/.claude-plugin/plugin.json`
+
+```json
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "MIT",
+  "keywords": [
+    "personal",
+    "brainstorming",
+    "design",
+    "specs",
+    "workflow"
+  ]
+}
+```
+
+- [ ] **Step 3: Write `.codex-plugin/plugin.json`**
+
+Path: `plugins/workbench/.codex-plugin/plugin.json`
+
+```json
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "MIT",
+  "keywords": [
+    "personal",
+    "brainstorming",
+    "design",
+    "specs",
+    "workflow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workbench",
+    "shortDescription": "Personal forks of skills Pascal uses regularly",
+    "longDescription": "Personal fork-as-you-touch skill collection. Today: brainstorming (with visual companion) and a meta-skill that layers on top of using-superpowers. More skills will be added as Pascal commits to owning them.",
+    "developerName": "Pascal Göllner",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Help me brainstorm a new feature",
+      "Turn my idea into a spec",
+      "Run the design dialogue for this project"
+    ],
+    "screenshots": []
+  }
+}
+```
+
+- [ ] **Step 4: Copy LICENSE from upstream**
+
+```bash
+cp /home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/LICENSE /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/LICENSE
+```
+
+Verify the file is MIT:
+
+```bash
+head -3 /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/LICENSE
+```
+
+Expected: `MIT License` in the first line.
+
+- [ ] **Step 5: Write NOTICE**
+
+Path: `plugins/workbench/NOTICE`
+
+```
+Workbench
+
+This plugin is a personal fork of skills derived from the upstream
+Superpowers plugin by Jesse Vincent.
+
+Upstream: https://github.com/obra/superpowers
+Upstream version at fork time: 5.0.7
+Upstream license: MIT (see LICENSE file in this directory)
+
+Files derived from upstream Superpowers:
+
+  skills/brainstorming/SKILL.md
+  skills/brainstorming/visual-companion.md
+  skills/brainstorming/spec-document-reviewer-prompt.md
+  skills/brainstorming/scripts/frame-template.html
+  skills/brainstorming/scripts/helper.js
+  skills/brainstorming/scripts/server.cjs
+  skills/brainstorming/scripts/start-server.sh
+  skills/brainstorming/scripts/stop-server.sh
+  skills/using-workbench/references/using-superpowers-upstream.md
+  hooks/hooks.json
+  hooks/run-hook.cmd
+  hooks/session-start
+
+Adaptations from upstream are documented in
+docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md.
+```
+
+- [ ] **Step 6: Write README.md**
+
+Path: `plugins/workbench/README.md`
+
+```markdown
+# Workbench
+
+Personal fork-as-you-touch skill collection.
+
+## Skills
+
+- `brainstorming`: Design dialogue that turns an idea into a spec, with a visual-companion mode for browser-based mockups. Forked from upstream Superpowers and adapted with Workbench-specific paths.
+- `using-workbench`: Trimmed meta-skill that announces what Workbench ships and resolves slug collisions in Workbench's favor. Defers core meta-rules to the upstream `using-superpowers` skill.
+
+## Coexistence
+
+Workbench is designed to run alongside the upstream `superpowers` plugin. When a slug exists in both plugins (today: `brainstorming`), prefer the Workbench version.
+
+The brainstorming skill's terminal handoff currently invokes `superpowers:writing-plans` cross-plugin. When `writing-plans` is later ported into Workbench, that reference will flip.
+
+## Credits
+
+This plugin includes content derived from the Superpowers plugin by Jesse Vincent (https://github.com/obra/superpowers), version 5.0.7, MIT-licensed. See the NOTICE file for the full list of derived files and the LICENSE file for the upstream license text.
+```
+
+- [ ] **Step 7: Verify JSON files parse**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+python3 -c "import json; json.load(open('plugins/workbench/.claude-plugin/plugin.json'))" && echo "claude plugin.json OK"
+python3 -c "import json; json.load(open('plugins/workbench/.codex-plugin/plugin.json'))" && echo "codex plugin.json OK"
+```
+
+Expected: both lines print `OK`.
+
+- [ ] **Step 8: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add plugins/workbench/.claude-plugin plugins/workbench/.codex-plugin plugins/workbench/LICENSE plugins/workbench/NOTICE plugins/workbench/README.md
+git commit -m "feat(workbench): scaffold plugin structure with manifests and license attribution"
+```
+
+---
+
+## Task 3: Add using-workbench meta-skill
+
+**Files:**
+- Create: `plugins/workbench/skills/using-workbench/SKILL.md`
+- Create: `plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md`
+
+- [ ] **Step 1: Write using-workbench/SKILL.md**
+
+Path: `plugins/workbench/skills/using-workbench/SKILL.md`
+
+```markdown
+---
+name: using-workbench
+description: Use when starting any conversation alongside using-superpowers. Announces workbench's currently-shipped skills, defers meta-rules to using-superpowers, and resolves slug collisions in workbench's favor.
+---
+
+# Using Workbench
+
+This skill is a thin companion to `using-superpowers`. Workbench layers on top of the upstream Superpowers plugin and forks individual skills as Pascal commits to owning them.
+
+## Relationship to using-superpowers
+
+The meta-rules for working with skills (when to invoke them, how to treat triggers, the "even 1% relevance" rule, the rule against rationalizing past skill use, the SUBAGENT-STOP block, the platform tool-name mapping) are owned by `using-superpowers`. This skill does NOT restate them.
+
+If `superpowers` is not installed, see `references/using-superpowers-upstream.md` in this skill directory for the meta-rules in their original form, frozen at upstream version 5.0.7. Either install upstream, or promote that content into this skill body.
+
+## Workbench skills
+
+Today, Workbench ships:
+
+- `brainstorming`: design dialogue that turns an idea into a spec, with a visual-companion mode
+
+As more skills are forked into Workbench, add them to this list and promote relevant chunks from `references/using-superpowers-upstream.md` into this skill body.
+
+## Slug collision rule
+
+When a skill name exists in both Workbench and Superpowers, prefer the Workbench version. Today the only collision is `brainstorming`. The host agent should resolve the bare slug `brainstorming` to `workbench:brainstorming`.
+
+## Reference file
+
+`references/using-superpowers-upstream.md` is a verbatim snapshot of the upstream `using-superpowers/SKILL.md` at version 5.0.7. It exists so that, as more skills are ported, their corresponding chunks of meta-guidance can be lifted out of the snapshot and into this skill body.
+```
+
+- [ ] **Step 2: Copy upstream using-superpowers as reference**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+cp /home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/using-superpowers/SKILL.md \
+   plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md
+```
+
+- [ ] **Step 3: Prepend snapshot header to reference file**
+
+Use the Edit tool to add a header note at the top of `plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md`. Find the existing first line of the file (which begins with `---` for frontmatter) and prepend an HTML comment block above it.
+
+Insert at the very top of the file (before any other content):
+
+```html
+<!--
+SNAPSHOT NOTE
+=============
+Source: superpowers plugin v5.0.7
+Origin path: skills/using-superpowers/SKILL.md
+Snapshot date: 2026-05-04
+Purpose: Frozen reference for the using-workbench skill. As Workbench
+forks more skills from upstream, lift the corresponding chunks of
+meta-guidance out of this file and into using-workbench/SKILL.md.
+This file is intentionally NOT a skill (no frontmatter recognized as
+skill metadata; subdirectory `references/` is by convention not loaded
+as a skill).
+-->
+
+```
+
+(Note the trailing blank line so the original frontmatter stays at column 1 of its own line.)
+
+- [ ] **Step 4: Verify both files exist and are non-empty**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+test -s plugins/workbench/skills/using-workbench/SKILL.md && echo "SKILL.md OK"
+test -s plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md && echo "reference OK"
+head -5 plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md
+```
+
+Expected: both `OK` lines, and head shows the snapshot note comment first.
+
+- [ ] **Step 5: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add plugins/workbench/skills/using-workbench/
+git commit -m "feat(workbench): add using-workbench meta-skill with upstream reference snapshot"
+```
+
+---
+
+## Task 4: Port brainstorming skill files (verbatim copies)
+
+**Files:**
+- Create: `plugins/workbench/skills/brainstorming/SKILL.md`
+- Create: `plugins/workbench/skills/brainstorming/visual-companion.md`
+- Create: `plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md`
+- Create: `plugins/workbench/skills/brainstorming/scripts/frame-template.html`
+- Create: `plugins/workbench/skills/brainstorming/scripts/helper.js`
+- Create: `plugins/workbench/skills/brainstorming/scripts/server.cjs`
+- Create: `plugins/workbench/skills/brainstorming/scripts/start-server.sh`
+- Create: `plugins/workbench/skills/brainstorming/scripts/stop-server.sh`
+
+This task is verbatim copies. Rebrand edits happen in Task 5.
+
+- [ ] **Step 1: Copy all brainstorming files**
+
+```bash
+SRC=/home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/brainstorming
+DST=/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/skills/brainstorming
+
+cp "$SRC/SKILL.md" "$DST/SKILL.md"
+cp "$SRC/visual-companion.md" "$DST/visual-companion.md"
+cp "$SRC/spec-document-reviewer-prompt.md" "$DST/spec-document-reviewer-prompt.md"
+cp "$SRC/scripts/frame-template.html" "$DST/scripts/frame-template.html"
+cp "$SRC/scripts/helper.js" "$DST/scripts/helper.js"
+cp "$SRC/scripts/server.cjs" "$DST/scripts/server.cjs"
+cp "$SRC/scripts/start-server.sh" "$DST/scripts/start-server.sh"
+cp "$SRC/scripts/stop-server.sh" "$DST/scripts/stop-server.sh"
+```
+
+- [ ] **Step 2: Preserve executable bits on shell scripts**
+
+```bash
+DST=/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/skills/brainstorming/scripts
+chmod +x "$DST/start-server.sh" "$DST/stop-server.sh"
+ls -la "$DST"/*.sh
+```
+
+Expected: `start-server.sh` and `stop-server.sh` show `-rwxr-xr-x` (or equivalent with x bit).
+
+- [ ] **Step 3: Verify all eight files copied with non-zero size**
+
+```bash
+DST=/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/skills/brainstorming
+for f in SKILL.md visual-companion.md spec-document-reviewer-prompt.md scripts/frame-template.html scripts/helper.js scripts/server.cjs scripts/start-server.sh scripts/stop-server.sh; do
+  test -s "$DST/$f" && echo "$f OK" || echo "$f MISSING"
+done
+```
+
+Expected: 8 lines all ending in `OK`.
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add plugins/workbench/skills/brainstorming/
+git commit -m "feat(workbench): port brainstorming skill files verbatim from superpowers v5.0.7"
+```
+
+---
+
+## Task 5: Apply brainstorming rebrand edits
+
+**Files (all paths worktree-relative):**
+- Modify: `plugins/workbench/skills/brainstorming/SKILL.md` (spec output path + terminal handoff target)
+- Modify: `plugins/workbench/skills/brainstorming/scripts/start-server.sh` (lines 9, 81)
+- Modify: `plugins/workbench/skills/brainstorming/scripts/stop-server.sh` (line 6)
+- Modify: `plugins/workbench/skills/brainstorming/scripts/frame-template.html` (line 199)
+- Modify: `plugins/workbench/skills/brainstorming/visual-companion.md` (multiple `.superpowers/brainstorm/` references)
+
+These are surgical edits. Use the Edit tool with the exact strings shown.
+
+- [ ] **Step 1: Edit SKILL.md, spec output path**
+
+File: `plugins/workbench/skills/brainstorming/SKILL.md`
+
+Find:
+
+```
+- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+```
+
+Replace with:
+
+```
+- Write the validated design (spec) to `docs/workbench/specs/YYYY-MM-DD-<topic>-design.md`
+```
+
+- [ ] **Step 2: Edit SKILL.md, terminal handoff target**
+
+File: `plugins/workbench/skills/brainstorming/SKILL.md`
+
+Find:
+
+```
+- Invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other skill. writing-plans is the next step.
+```
+
+Replace with:
+
+```
+- Invoke the `superpowers:writing-plans` skill to create a detailed implementation plan
+- Do NOT invoke any other skill. `superpowers:writing-plans` is the next step. (When `writing-plans` is later ported into Workbench, this reference flips to `workbench:writing-plans`.)
+```
+
+Also find any other line that references `writing-plans` without the plugin prefix and update similarly. Specifically look for these existing strings in the SKILL.md and update them too:
+
+Find:
+
+```
+"The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans."
+```
+
+Replace with:
+
+```
+"The terminal state is invoking `superpowers:writing-plans`.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is `superpowers:writing-plans`."
+```
+
+And:
+
+Find (in the dot graph):
+
+```
+"Invoke writing-plans skill" [shape=doublecircle];
+```
+
+Replace with:
+
+```
+"Invoke superpowers:writing-plans skill" [shape=doublecircle];
+```
+
+And:
+
+Find:
+
+```
+    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+```
+
+Replace with:
+
+```
+    "User reviews spec?" -> "Invoke superpowers:writing-plans skill" [label="approved"];
+```
+
+Also update the checklist line:
+
+Find:
+
+```
+9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+```
+
+Replace with:
+
+```
+9. **Transition to implementation** — invoke `superpowers:writing-plans` skill to create implementation plan
+```
+
+- [ ] **Step 3: Edit start-server.sh, comment on line 9**
+
+File: `plugins/workbench/skills/brainstorming/scripts/start-server.sh`
+
+Find:
+
+```
+#   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
+```
+
+Replace with:
+
+```
+#   --project-dir <path>  Store session files under <path>/.workbench/brainstorm/
+```
+
+- [ ] **Step 4: Edit start-server.sh, session dir on line 81**
+
+File: `plugins/workbench/skills/brainstorming/scripts/start-server.sh`
+
+Find:
+
+```
+  SESSION_DIR="${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}"
+```
+
+Replace with:
+
+```
+  SESSION_DIR="${PROJECT_DIR}/.workbench/brainstorm/${SESSION_ID}"
+```
+
+- [ ] **Step 5: Edit stop-server.sh, comment on line 6**
+
+File: `plugins/workbench/skills/brainstorming/scripts/stop-server.sh`
+
+Find:
+
+```
+# under /tmp (ephemeral). Persistent directories (.superpowers/) are
+```
+
+Replace with:
+
+```
+# under /tmp (ephemeral). Persistent directories (.workbench/) are
+```
+
+- [ ] **Step 6: Edit frame-template.html, page header**
+
+File: `plugins/workbench/skills/brainstorming/scripts/frame-template.html`
+
+Find:
+
+```
+    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+```
+
+Replace with:
+
+```
+    <h1><a href="https://github.com/pgoell/pgoell-claude-tools" style="color: inherit; text-decoration: none;">Workbench Brainstorming</a></h1>
+```
+
+- [ ] **Step 7: Edit visual-companion.md, replace all .superpowers/ path references**
+
+File: `plugins/workbench/skills/brainstorming/visual-companion.md`
+
+Replace all four references. Each replacement uses the Edit tool with `replace_all: true` since the same path appears in multiple locations.
+
+Find (use `replace_all: true`):
+
+```
+.superpowers/brainstorm/
+```
+
+Replace with:
+
+```
+.workbench/brainstorm/
+```
+
+Then find:
+
+```
+add `.superpowers/`
+```
+
+Replace with:
+
+```
+add `.workbench/`
+```
+
+- [ ] **Step 8: Verify rebrand completeness**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/skills/brainstorming
+echo "--- residual superpowers references in code paths ---"
+grep -rn "superpowers" . | grep -v "writing-plans" | grep -v "obra"
+echo "--- (the only acceptable hits should be the deliberate superpowers:writing-plans handoff in SKILL.md and the github.com/obra/superpowers attribution in NOTICE-style content if any) ---"
+```
+
+Expected: only matches are inside the SKILL.md, referencing `superpowers:writing-plans` (the deliberate cross-plugin handoff). If `frame-template.html` or scripts show any remaining `superpowers` strings, fix them and re-grep.
+
+- [ ] **Step 9: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add plugins/workbench/skills/brainstorming/
+git commit -m "feat(workbench): rebrand brainstorming skill paths and references for workbench"
+```
+
+---
+
+## Task 6: Add hook scripts and configs (Claude + Codex)
+
+**Files:**
+- Create: `plugins/workbench/hooks/run-hook.cmd`
+- Create: `plugins/workbench/hooks/session-start`
+- Create: `plugins/workbench/hooks/hooks.json`
+- Create: `plugins/workbench/hooks.json`
+
+- [ ] **Step 1: Copy run-hook.cmd verbatim**
+
+```bash
+cp /home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/hooks/run-hook.cmd \
+   /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/hooks/run-hook.cmd
+```
+
+The file is a generic cross-platform polyglot wrapper with no upstream-specific references; no edits needed.
+
+- [ ] **Step 2: Copy session-start as a starting point**
+
+```bash
+cp /home/pascal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/hooks/session-start \
+   /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/hooks/session-start
+```
+
+- [ ] **Step 3: Edit session-start, header comment**
+
+File: `plugins/workbench/hooks/session-start`
+
+Find:
+
+```
+# SessionStart hook for superpowers plugin
+```
+
+Replace with:
+
+```
+# SessionStart hook for workbench plugin
+```
+
+- [ ] **Step 4: Edit session-start, drop legacy-skills-warning block**
+
+File: `plugins/workbench/hooks/session-start`
+
+Find (this is the entire block including the variable initialization, the if-statement, and the warning message string):
+
+```bash
+# Check if legacy skills directory exists and build warning
+warning_message=""
+legacy_skills_dir="${HOME}/.config/superpowers/skills"
+if [ -d "$legacy_skills_dir" ]; then
+    warning_message="\n\n<important-reminder>IN YOUR FIRST REPLY AFTER SEEING THIS MESSAGE YOU MUST TELL THE USER:⚠️ **WARNING:** Superpowers now uses Claude Code's skills system. Custom skills in ~/.config/superpowers/skills will not be read. Move custom skills to ~/.claude/skills instead. To make this message go away, remove ~/.config/superpowers/skills</important-reminder>"
+fi
+```
+
+Replace with: (empty, just remove the block).
+
+- [ ] **Step 5: Edit session-start, skill path read**
+
+File: `plugins/workbench/hooks/session-start`
+
+Find:
+
+```bash
+# Read using-superpowers content
+using_superpowers_content=$(cat "${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md" 2>&1 || echo "Error reading using-superpowers skill")
+```
+
+Replace with:
+
+```bash
+# Read using-workbench content
+using_workbench_content=$(cat "${PLUGIN_ROOT}/skills/using-workbench/SKILL.md" 2>&1 || echo "Error reading using-workbench skill")
+```
+
+- [ ] **Step 6: Edit session-start, variable rename in escape block**
+
+File: `plugins/workbench/hooks/session-start`
+
+Find:
+
+```bash
+using_superpowers_escaped=$(escape_for_json "$using_superpowers_content")
+warning_escaped=$(escape_for_json "$warning_message")
+session_context="<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, use the 'Skill' tool:**\n\n${using_superpowers_escaped}\n\n${warning_escaped}\n</EXTREMELY_IMPORTANT>"
+```
+
+Replace with:
+
+```bash
+using_workbench_escaped=$(escape_for_json "$using_workbench_content")
+session_context="<EXTREMELY_IMPORTANT>\nYou have workbench skills.\n\n**Below is the full content of your 'workbench:using-workbench' skill, your introduction to using Workbench skills alongside the upstream Superpowers meta-rules. For all other skills, use the 'Skill' tool:**\n\n${using_workbench_escaped}\n</EXTREMELY_IMPORTANT>"
+```
+
+This change does three things at once: drops `warning_escaped` (no longer used), renames the content variable, and rebrands the wrapper text.
+
+- [ ] **Step 7: Verify session-start has no remaining `superpowers` references and is syntactically valid bash**
+
+```bash
+SESSION_START=/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/hooks/session-start
+echo "--- residual superpowers in session-start ---"
+grep -n "superpowers" "$SESSION_START" || echo "(none)"
+echo "--- bash syntax check ---"
+bash -n "$SESSION_START" && echo "syntax OK"
+```
+
+Expected: `(none)` for the grep (or only an `obra/superpowers` URL if any survived; that's acceptable since it would be inside a comment), and `syntax OK` for the bash check.
+
+- [ ] **Step 8: Make scripts executable**
+
+```bash
+HOOKS=/home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/plugins/workbench/hooks
+chmod +x "$HOOKS/session-start" "$HOOKS/run-hook.cmd"
+ls -la "$HOOKS"
+```
+
+Expected: both `session-start` and `run-hook.cmd` show executable bits.
+
+- [ ] **Step 9: Write hooks/hooks.json (Claude Code)**
+
+Path: `plugins/workbench/hooks/hooks.json`
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 10: Write hooks.json at plugin root (Codex)**
+
+Path: `plugins/workbench/hooks.json`
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/session-start"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 11: Verify both hook configs parse**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+python3 -c "import json; json.load(open('plugins/workbench/hooks/hooks.json'))" && echo "claude hooks.json OK"
+python3 -c "import json; json.load(open('plugins/workbench/hooks.json'))" && echo "codex hooks.json OK"
+```
+
+Expected: both lines print `OK`.
+
+- [ ] **Step 12: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add plugins/workbench/hooks/ plugins/workbench/hooks.json
+git commit -m "feat(workbench): add SessionStart hook for Claude Code and Codex"
+```
+
+---
+
+## Task 7: Register workbench in marketplaces
+
+**Files:**
+- Modify: `.claude-plugin/marketplace.json` (add workbench entry to `plugins` array)
+- Modify: `.agents/plugins/marketplace.json` (add workbench entry to `plugins` array)
+
+- [ ] **Step 1: Edit `.claude-plugin/marketplace.json`**
+
+File: `.claude-plugin/marketplace.json`
+
+Append a new entry to the `plugins` array. Find the closing `]` of the existing plugins array (the last entry currently is `agents-md-management`). Add a comma after the closing brace of the agents-md-management entry, then insert the new workbench object before the closing `]`.
+
+Find:
+
+```json
+    {
+      "name": "agents-md-management",
+      "source": "./plugins/agents-md-management",
+      "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
+      "version": "0.1.0"
+    }
+  ]
+```
+
+Replace with:
+
+```json
+    {
+      "name": "agents-md-management",
+      "source": "./plugins/agents-md-management",
+      "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
+      "version": "0.1.0"
+    },
+    {
+      "name": "workbench",
+      "source": "./plugins/workbench",
+      "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+      "version": "0.1.0"
+    }
+  ]
+```
+
+- [ ] **Step 2: Edit `.agents/plugins/marketplace.json`**
+
+File: `.agents/plugins/marketplace.json`
+
+Same pattern: insert the new workbench entry as the last item in the `plugins` array.
+
+Find:
+
+```json
+    {
+      "name": "agents-md-management",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agents-md-management"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Agents.md Management",
+        "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
+      }
+    }
+  ]
+```
+
+Replace with:
+
+```json
+    {
+      "name": "agents-md-management",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agents-md-management"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Agents.md Management",
+        "shortDescription": "Audit AGENTS.md/CLAUDE.md and capture session learnings"
+      }
+    },
+    {
+      "name": "workbench",
+      "source": {
+        "source": "local",
+        "path": "./plugins/workbench"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity",
+      "interface": {
+        "displayName": "Workbench",
+        "shortDescription": "Personal forks of skills Pascal uses regularly"
+      }
+    }
+  ]
+```
+
+- [ ] **Step 3: Verify both marketplace files parse**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+python3 -c "import json; data=json.load(open('.claude-plugin/marketplace.json')); print('claude marketplace OK,', len(data['plugins']), 'plugins')"
+python3 -c "import json; data=json.load(open('.agents/plugins/marketplace.json')); print('codex marketplace OK,', len(data['plugins']), 'plugins')"
+```
+
+Expected: both report `OK` with plugin count of 7 (was 6, added workbench).
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add .claude-plugin/marketplace.json .agents/plugins/marketplace.json
+git commit -m "feat(workbench): register plugin in Claude Code and Codex marketplaces"
+```
+
+---
+
+## Task 8: Update repo README.md
+
+**Files:**
+- Modify: `README.md` (Plugins section + Installation section)
+
+- [ ] **Step 1: Add Workbench to the Plugins section**
+
+File: `README.md`
+
+The existing Plugins section lists six plugins as `### <name>` subsections, in this order: atlassian, google-workspace, research, writing, runtime-bridge, agents-md-management.
+
+Find the last subsection `### agents-md-management` and the content beneath it. Find the line that ends that subsection (whatever follows before the next `## ` top-level heading begins). Append a new `### workbench` subsection.
+
+Concretely, find the closing line of the agents-md-management subsection. To make the edit unambiguous, locate the heading `### agents-md-management` by reading lines 60 through 72 of `README.md` to see what follows. Then append:
+
+```markdown
+### workbench
+
+Personal fork-as-you-touch skill collection. Today: brainstorming (a design dialogue that turns ideas into specs, with a browser-based visual companion) and a trimmed meta-skill that layers on top of upstream `superpowers:using-superpowers`. More skills will be added as Pascal commits to owning them.
+
+**Skills:**
+- `/pgoell-claude-tools:brainstorming`: Design dialogue from idea to spec, with a visual-companion mode
+- `/pgoell-claude-tools:using-workbench`: Meta-skill announcing Workbench skills, defers core meta-rules to upstream
+```
+
+Insert this `### workbench` block immediately before the next top-level heading (`## Installation`).
+
+- [ ] **Step 2: Add Workbench to the Installation section (Claude Code)**
+
+File: `README.md`
+
+Find:
+
+```
+/plugin install agents-md-management@pgoell-claude-tools
+```
+
+Replace with:
+
+```
+/plugin install agents-md-management@pgoell-claude-tools
+/plugin install workbench@pgoell-claude-tools
+```
+
+- [ ] **Step 3: Verify the README still renders sensibly**
+
+```bash
+head -100 /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/README.md
+grep -n "workbench" /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench/README.md
+```
+
+Expected: at least three matches for `workbench` (heading, skill listings, install command).
+
+- [ ] **Step 4: Stage and commit**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git add README.md
+git commit -m "docs(workbench): document workbench plugin in repo README"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** None modified. This task is read-only verification.
+
+- [ ] **Step 1: All JSON files in workbench parse**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+for f in $(find plugins/workbench .claude-plugin/marketplace.json .agents/plugins/marketplace.json -name "*.json" 2>/dev/null); do
+  python3 -c "import json; json.load(open('$f'))" 2>/dev/null && echo "$f OK" || echo "$f FAILED"
+done
+```
+
+Expected: every file ends in `OK`. (Files checked: workbench plugin manifests, both hook configs, both marketplace files.)
+
+- [ ] **Step 2: All shell scripts in workbench are executable**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+for f in plugins/workbench/hooks/session-start plugins/workbench/hooks/run-hook.cmd plugins/workbench/skills/brainstorming/scripts/start-server.sh plugins/workbench/skills/brainstorming/scripts/stop-server.sh; do
+  if [ -x "$f" ]; then echo "$f executable"; else echo "$f NOT executable"; fi
+done
+```
+
+Expected: all four files marked `executable`.
+
+- [ ] **Step 3: All shell scripts in workbench have valid bash syntax**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+for f in plugins/workbench/hooks/session-start plugins/workbench/skills/brainstorming/scripts/start-server.sh plugins/workbench/skills/brainstorming/scripts/stop-server.sh; do
+  bash -n "$f" && echo "$f syntax OK" || echo "$f SYNTAX ERROR"
+done
+```
+
+Expected: all three files report `syntax OK`.
+
+- [ ] **Step 4: Audit residual `superpowers` references**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+echo "--- All superpowers references inside plugins/workbench (excluding the snapshot reference file) ---"
+grep -rn "superpowers" plugins/workbench --exclude-dir=references
+echo ""
+echo "--- Acceptable remaining hits should be: ---"
+echo "  * superpowers:writing-plans (deliberate cross-plugin handoff in brainstorming SKILL.md)"
+echo "  * obra/superpowers (upstream attribution URL in NOTICE)"
+echo "  * 'using-superpowers' inside using-workbench/SKILL.md text discussing the upstream relationship"
+```
+
+Expected: only the documented acceptable hits appear.
+
+- [ ] **Step 5: Verify Codex plugin structure test passes (if applicable)**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+if [ -f tests/unit/test-codex-plugin-structure.sh ]; then
+  bash tests/unit/test-codex-plugin-structure.sh
+else
+  echo "(no codex structure test script in repo)"
+fi
+```
+
+Expected: test passes (or, if the test does not yet exist in this repo state, the message about missing script). If the test exists and fails, investigate the failure: it likely indicates a manifest field mismatch.
+
+- [ ] **Step 6: Inspect commit graph**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+git log --oneline main..HEAD
+```
+
+Expected: roughly 8 commits ahead of main. The exact list, top to bottom (most recent first):
+
+1. docs(workbench): document workbench plugin in repo README
+2. feat(workbench): register plugin in Claude Code and Codex marketplaces
+3. feat(workbench): add SessionStart hook for Claude Code and Codex
+4. feat(workbench): rebrand brainstorming skill paths and references for workbench
+5. feat(workbench): port brainstorming skill files verbatim from superpowers v5.0.7
+6. feat(workbench): add using-workbench meta-skill with upstream reference snapshot
+7. feat(workbench): scaffold plugin structure with manifests and license attribution
+8. docs(workbench): add brainstorming port design spec and implementation plan
+
+If commits are missing or out of order, do not auto-fix; pause and report to the user.
+
+- [ ] **Step 7: Inspect file inventory matches the spec**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+find plugins/workbench -type f | sort
+```
+
+Expected file list (compare against the spec's `## Plugin shape` section):
+
+```
+plugins/workbench/.claude-plugin/plugin.json
+plugins/workbench/.codex-plugin/plugin.json
+plugins/workbench/LICENSE
+plugins/workbench/NOTICE
+plugins/workbench/README.md
+plugins/workbench/hooks.json
+plugins/workbench/hooks/hooks.json
+plugins/workbench/hooks/run-hook.cmd
+plugins/workbench/hooks/session-start
+plugins/workbench/skills/brainstorming/SKILL.md
+plugins/workbench/skills/brainstorming/scripts/frame-template.html
+plugins/workbench/skills/brainstorming/scripts/helper.js
+plugins/workbench/skills/brainstorming/scripts/server.cjs
+plugins/workbench/skills/brainstorming/scripts/start-server.sh
+plugins/workbench/skills/brainstorming/scripts/stop-server.sh
+plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md
+plugins/workbench/skills/brainstorming/visual-companion.md
+plugins/workbench/skills/using-workbench/SKILL.md
+plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md
+```
+
+If any file is missing, identify which task should have created it and fix that task.
+
+- [ ] **Step 8: Optional skill-triggering smoke test**
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+if [ -f tests/skill-triggering/run-test.sh ]; then
+  echo "Brainstorming auto-trigger test would run here. Skipping execution since the spec defers tests as IOUs and the runner depends on live Claude invocations."
+fi
+```
+
+This step is informational only; do not block on it.
+
+- [ ] **Step 9: Final summary**
+
+If all prior steps passed: print a short summary of what was built, ready for handoff to PR creation.
+
+```bash
+cd /home/pascal/Code/pgoell-claude-tools/.worktrees/workbench
+echo "=== Workbench port complete ==="
+echo "Branch: $(git branch --show-current)"
+echo "Commits ahead of main: $(git rev-list --count main..HEAD)"
+echo "Plugin file count: $(find plugins/workbench -type f | wc -l)"
+echo "Marketplaces updated: claude + codex"
+echo ""
+echo "Ready for PR creation."
+```
+
+---
+
+## Cleanup note (post-merge, not part of this plan)
+
+After this PR merges, the original spec file at `/home/pascal/Code/pgoell-claude-tools/docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md` (in the main working tree, copied here at worktree creation) becomes redundant. Once the worktree is finished, that copy can be removed from the main working tree. This is not required for the PR itself; it's a tidy-up note.
+
+---
+
+## Self-review notes (for the author of this plan)
+
+Spec coverage check:
+- Plugin shape: covered by Task 2 (scaffold) + Tasks 3, 4, 6 (skills + hooks).
+- File-by-file adaptations: every file listed in the spec has a corresponding step.
+- Marketplace metadata: covered by Task 7.
+- License and attribution: covered by Task 2 (LICENSE, NOTICE, README skeleton).
+- Out-of-scope IOUs: deliberately omitted from execution; documented in spec only.
+
+Placeholder scan:
+- No "TBD", "TODO", "implement later".
+- All edits show explicit find/replace strings.
+- All commands have explicit expected output.
+
+Type/identifier consistency:
+- Variable rename `using_superpowers_*` to `using_workbench_*` is applied in two consecutive steps (Step 5 and Step 6 of Task 6) to keep the file consistent.
+- `superpowers:writing-plans` cross-plugin reference is used identically wherever it appears.
+
+Style:
+- No em-dashes in newly authored prose.
+- No en-dashes.
+- No sentence-hyphen punctuation.
+- Verbatim upstream content is not edited for style; that is part of the "clean port today" decision in the spec.

--- a/docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md
+++ b/docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md
@@ -1,0 +1,252 @@
+# Workbench plugin: initial port (brainstorming + meta-skill)
+
+**Date:** 2026-05-04
+**Status:** Approved, ready for implementation plan
+**Owner:** Pascal Göllner
+
+## Summary
+
+Create a new `workbench` plugin in `pgoell-claude-tools` that holds Pascal's personal forks of skills he uses regularly. Initial scope: port `brainstorming` and a trimmed meta-skill `using-workbench` from the upstream `superpowers` plugin (v5.0.7), with full Claude Code and Codex parity per repo convention.
+
+The plugin operates in fork-as-you-touch mode: workbench coexists with the upstream `superpowers` plugin, and only ports skills that have been explicitly adopted. The brainstorming skill's terminal handoff continues to invoke `superpowers:writing-plans` cross-plugin until that skill is also ported in a future wave.
+
+## Motivation
+
+Pascal wants to own all skills he uses rather than collecting them piecemeal from different sources. Workbench will be the long-term home for that ownership: today brainstorming + meta-skill, over time more skills as he commits to using them, and eventually general dev automations beyond what upstream provides.
+
+## Decisions
+
+These were resolved through brainstorming dialogue:
+
+1. **Plugin name:** `workbench`. Activity-style name (matching `research`, `writing`) rather than vendor or personal namespace. Accommodates non-strictly-dev skills like brainstorming.
+2. **Port mode:** Fork-as-you-touch. Workbench ships only skills Pascal has decided to adapt or own. Upstream `superpowers` remains installed and provides skills not yet ported.
+3. **Meta-skill shape:** Trimmed companion. `using-workbench` is short (~30 lines), defers all "invoke skills, be disciplined" meta-rules to upstream `using-superpowers`, and announces the workbench skill list plus a collision-resolution rule. Full upstream content is preserved verbatim in `using-workbench/references/using-superpowers-upstream.md` for incremental promotion as more skills are ported.
+4. **Adaptations:** Clean port today, no design changes. Pascal has no specific gripes with the upstream brainstorming skill yet. He will discover frictions through actual use and iterate from there.
+5. **Hook coverage:** Dual-runtime. Both Claude Code (`hooks/hooks.json`) and Codex (`hooks.json` at plugin root) declare a SessionStart hook that injects `using-workbench/SKILL.md`. Claude Code support is upstream-equivalent and known-working. Codex support follows the schema demonstrated by the openai-curated `figma` plugin; the figma hook script self-describes as "draft for future plugin hook runtimes," so Codex may recognize the schema today without yet firing it. Either way, the parity cost is small and the hook fires automatically once Codex enables the runtime.
+
+## Plugin shape
+
+```
+plugins/workbench/
+  .claude-plugin/
+    plugin.json                        # Claude Code manifest
+  .codex-plugin/
+    plugin.json                        # Codex manifest with full interface block
+  LICENSE                              # MIT, copied from upstream
+  NOTICE                               # upstream attribution per repo memory rule
+  README.md                            # plugin overview with Credits section
+  hooks/
+    hooks.json                         # Claude Code hook config (uses ${CLAUDE_PLUGIN_ROOT})
+    run-hook.cmd                       # platform dispatcher, ported from upstream
+    session-start                      # bash script, ported from upstream
+  hooks.json                           # Codex hook config at plugin root, uses relative ./hooks/session-start
+  skills/
+    using-workbench/
+      SKILL.md                         # trimmed companion meta-skill
+      references/
+        using-superpowers-upstream.md  # frozen verbatim copy of upstream using-superpowers/SKILL.md @ v5.0.7
+    brainstorming/
+      SKILL.md                         # rebranded port
+      visual-companion.md              # rebranded port
+      spec-document-reviewer-prompt.md # straight copy
+      scripts/
+        frame-template.html            # rebranded
+        helper.js                      # straight copy
+        server.cjs                     # straight copy
+        start-server.sh                # rebranded paths
+        stop-server.sh                 # rebranded paths
+```
+
+Both runtimes read the same `skills/` tree. Claude Code reads `hooks/hooks.json` (and ignores the root `hooks.json`). Codex reads the root `hooks.json` (and ignores the nested one). Both invoke the same `hooks/session-start` script, which derives its plugin root from `$0` and works under either runtime.
+
+## File-by-file adaptations from upstream
+
+### `skills/brainstorming/SKILL.md`
+
+* Spec output path: `docs/superpowers/specs/` becomes `docs/workbench/specs/`.
+* Terminal handoff text: explicitly invokes `superpowers:writing-plans` (cross-plugin reference, honest about today's dependency). When `writing-plans` is later ported into workbench, this reference flips to `workbench:writing-plans` as part of that port.
+* All other content kept verbatim. No tone changes, no workflow changes, no checkpoint changes.
+
+### `skills/brainstorming/scripts/start-server.sh`
+
+* Line 9 comment: `.superpowers/` becomes `.workbench/`.
+* Line 81 path: `${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}` becomes `${PROJECT_DIR}/.workbench/brainstorm/${SESSION_ID}`.
+
+### `skills/brainstorming/scripts/stop-server.sh`
+
+* Line 6 comment: `.superpowers/` becomes `.workbench/`.
+
+### `skills/brainstorming/scripts/frame-template.html`
+
+* Line 199: rebrand the page header. The upstream string `Superpowers Brainstorming` linked to `https://github.com/obra/superpowers` becomes `Workbench Brainstorming` linked to `https://github.com/pgoell/pgoell-claude-tools`.
+
+### `skills/brainstorming/visual-companion.md`
+
+* All `.superpowers/brainstorm/` references become `.workbench/brainstorm/`.
+* `.gitignore` advice references `.workbench/` instead of `.superpowers/`.
+
+### `skills/brainstorming/spec-document-reviewer-prompt.md`
+
+* Straight copy. No upstream-specific references to fix.
+
+### `skills/brainstorming/scripts/helper.js`, `server.cjs`
+
+* Straight copies. No upstream-specific references to fix.
+
+### `skills/using-workbench/SKILL.md` (new)
+
+Frontmatter:
+
+```yaml
+---
+name: using-workbench
+description: Use when starting any conversation alongside using-superpowers. Announces workbench's currently-shipped skills, defers meta-rules to using-superpowers, and resolves slug collisions in workbench's favor.
+---
+```
+
+Body covers, in this order:
+
+1. **Relationship to using-superpowers.** Workbench layers on top of upstream superpowers. Meta-rules ("invoke relevant skills before responding," "even 1% relevance is enough," etc.) are owned by `using-superpowers`. This skill does not restate them. If `superpowers` is not installed, see `references/using-superpowers-upstream.md` for the meta-rules in their original form and consider whether to install upstream or to promote that content here.
+2. **Workbench skills inventory.** Today: `brainstorming`. As skills are ported, add them here.
+3. **Slug collision rule.** When a skill name exists in both workbench and superpowers (today: `brainstorming`), prefer the workbench version. The host agent should resolve the slug `brainstorming` to `workbench:brainstorming`.
+4. **Pointer to upstream snapshot.** `references/using-superpowers-upstream.md` holds the full upstream `using-superpowers/SKILL.md` content frozen at v5.0.7. When a new skill is ported into workbench, lift the relevant chunks from that file into this skill's body.
+
+### `skills/using-workbench/references/using-superpowers-upstream.md`
+
+Verbatim copy of upstream `superpowers/skills/using-superpowers/SKILL.md` at v5.0.7. Header note documents the snapshot version, the original path, and the purpose of the file. Used as a source for incremental promotion into the trimmed companion above.
+
+### `hooks/hooks.json` (Claude Code)
+
+Mirrors upstream superpowers' `hooks/hooks.json` exactly, except the rebrand of the script invocation if needed (the script name `run-hook.cmd session-start` stays the same). Schema:
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### `hooks.json` (Codex, plugin root)
+
+```jsonc
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          { "type": "command", "command": "./hooks/session-start" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The relative path is plugin-root-relative, matching the figma plugin precedent. If Codex does not yet fire SessionStart hooks at runtime, this file sits inert until the runtime enables it. The cost of including it is negligible.
+
+### `hooks/run-hook.cmd`
+
+Verbatim copy of upstream. Generic cross-platform polyglot wrapper with no upstream-specific references.
+
+### `hooks/session-start`
+
+Ported from upstream with these adjustments:
+
+1. **Header comment.** `# SessionStart hook for superpowers plugin` becomes `# SessionStart hook for workbench plugin`.
+2. **Drop the legacy-skills-warning block.** The block that checks `${HOME}/.config/superpowers/skills` and builds `warning_message` is upstream-specific (a migration aid for old superpowers users) and not relevant to workbench. Remove the block, the `warning_message` variable, and its later inclusion in `session_context`.
+3. **Skill path read.** `${PLUGIN_ROOT}/skills/using-superpowers/SKILL.md` becomes `${PLUGIN_ROOT}/skills/using-workbench/SKILL.md`.
+4. **Rebrand `session_context` wrapper text.** The injected wrapper currently reads `<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill ...`. Rewrite to reference workbench: e.g. `<EXTREMELY_IMPORTANT>\nYou have workbench skills.\n\n**Below is the full content of your 'workbench:using-workbench' skill ...`.
+5. **Variable renames (cosmetic).** `using_superpowers_content` and `using_superpowers_escaped` become `using_workbench_content` and `using_workbench_escaped` for clarity. Functional equivalence preserved.
+
+The platform-detection block at the bottom (Cursor / Claude Code / Copilot CLI / SDK-standard else branch) is kept verbatim. Codex is expected to fall into the SDK-standard `additionalContext` else branch since no `CODEX_PLUGIN_ROOT` env var is documented and the figma plugin precedent uses plugin-root-relative paths without any env-var reference. This is an assumption to verify when Codex hooks are confirmed firing; if Codex needs different output framing, add a `CODEX_PLUGIN_ROOT` (or equivalent) check.
+
+## Marketplace metadata
+
+### `.claude-plugin/plugin.json`
+
+```json
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": { "name": "Pascal Göllner" },
+  "license": "MIT",
+  "keywords": ["personal", "brainstorming", "design", "specs", "workflow"]
+}
+```
+
+### `.codex-plugin/plugin.json`
+
+Same fields as Claude manifest plus the Codex-mandated extras per repo `CLAUDE.md`:
+
+```json
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": { "name": "Pascal Göllner" },
+  "license": "MIT",
+  "keywords": ["personal", "brainstorming", "design", "specs", "workflow"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workbench",
+    "shortDescription": "Personal forks of skills Pascal uses regularly",
+    "longDescription": "Personal fork-as-you-touch skill collection. Today: brainstorming (with visual companion) and a meta-skill that layers on top of using-superpowers. More skills will be added as Pascal commits to owning them.",
+    "developerName": "Pascal Göllner",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Write"],
+    "defaultPrompt": [
+      "Help me brainstorm a new feature",
+      "Turn my idea into a spec",
+      "Run the design dialogue for this project"
+    ],
+    "screenshots": []
+  }
+}
+```
+
+### Marketplace registration
+
+Add a `workbench` entry to both:
+
+* `.claude-plugin/marketplace.json` (Claude Code registry)
+* `.agents/plugins/marketplace.json` (Codex registry, with `interface.displayName` and `interface.shortDescription` per repo convention)
+
+## License and attribution
+
+Per the saved memory rule "Preserve upstream license attribution when porting":
+
+* `LICENSE`: MIT, copied verbatim from upstream `superpowers/LICENSE`.
+* `NOTICE`: credits upstream Superpowers (Jesse Vincent, https://github.com/obra/superpowers), version 5.0.7, with a link to the upstream LICENSE. Notes the files ported and adapted.
+* `README.md`: includes a "Credits" section pointing at upstream and naming the skills derived from it.
+
+## Out of scope today (deferred IOUs)
+
+Tracked for the next porting wave so they do not get lost:
+
+1. **Port `writing-plans` and `executing-plans`.** They are the natural next pair: `writing-plans` is brainstorming's terminal handoff target, and `executing-plans` is `writing-plans`' downstream. When done, the brainstorming SKILL.md flips its terminal reference from `superpowers:writing-plans` to `workbench:writing-plans`, and `using-workbench/SKILL.md` adds them to its inventory.
+2. **Port additional superpowers skills as Pascal commits to using them.** Candidates flagged by his actual workflow: `systematic-debugging`, `test-driven-development`, `verification-before-completion`, `using-git-worktrees`. Each is a separate fork decision.
+3. **Promote chunks of `using-superpowers-upstream.md` into `using-workbench/SKILL.md`** as more skills land in workbench. The reference file is the source; the skill body is the curated view.
+4. **Tests.** Per repo `CLAUDE.md` convention, plugins ship unit tests (skill recognition), skill-triggering tests (auto-trigger via natural prompts), and integration tests where applicable. Today's port deliberately ships without tests so the implementation plan covers a single coherent unit. Tests are tracked as a follow-up before workbench is considered production-ready, not as part of the initial port.
+5. **Investigate Codex hook firing.** The figma plugin precedent labels its hook "draft for future plugin hook runtimes." Once Codex hooks are confirmed firing in some version, document the verified-working version in this spec or a follow-up note. If they never fire, the dual-hook layout is harmless.
+
+## Open questions
+
+None at design time. All decisions are explicit above.
+
+## Implementation plan
+
+To be produced by the `superpowers:writing-plans` skill in the next phase. The plan should cover, in roughly this order: scaffold plugin directories, copy upstream files, apply the rebrand edits listed above, write the new `using-workbench` skill, write hook configs for both runtimes, write LICENSE/NOTICE/README, register in both marketplaces, and verify the manifest files parse via the existing repo unit-test runners.

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "MIT",
+  "keywords": [
+    "personal",
+    "brainstorming",
+    "design",
+    "specs",
+    "workflow"
+  ]
+}

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "workbench",
+  "version": "0.1.0",
+  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "MIT",
+  "keywords": [
+    "personal",
+    "brainstorming",
+    "design",
+    "specs",
+    "workflow"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Workbench",
+    "shortDescription": "Personal forks of skills Pascal uses regularly",
+    "longDescription": "Personal fork-as-you-touch skill collection. Today: brainstorming (with visual companion) and a meta-skill that layers on top of using-superpowers. More skills will be added as Pascal commits to owning them.",
+    "developerName": "Pascal Göllner",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Help me brainstorm a new feature",
+      "Turn my idea into a spec",
+      "Run the design dialogue for this project"
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/workbench/LICENSE
+++ b/plugins/workbench/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/workbench/NOTICE
+++ b/plugins/workbench/NOTICE
@@ -1,0 +1,26 @@
+Workbench
+
+This plugin is a personal fork of skills derived from the upstream
+Superpowers plugin by Jesse Vincent.
+
+Upstream: https://github.com/obra/superpowers
+Upstream version at fork time: 5.0.7
+Upstream license: MIT (see LICENSE file in this directory)
+
+Files derived from upstream Superpowers:
+
+  skills/brainstorming/SKILL.md
+  skills/brainstorming/visual-companion.md
+  skills/brainstorming/spec-document-reviewer-prompt.md
+  skills/brainstorming/scripts/frame-template.html
+  skills/brainstorming/scripts/helper.js
+  skills/brainstorming/scripts/server.cjs
+  skills/brainstorming/scripts/start-server.sh
+  skills/brainstorming/scripts/stop-server.sh
+  skills/using-workbench/references/using-superpowers-upstream.md
+  hooks/hooks.json
+  hooks/run-hook.cmd
+  hooks/session-start
+
+Adaptations from upstream are documented in
+docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md.

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -1,0 +1,18 @@
+# Workbench
+
+Personal fork-as-you-touch skill collection.
+
+## Skills
+
+- `brainstorming`: Design dialogue that turns an idea into a spec, with a visual-companion mode for browser-based mockups. Forked from upstream Superpowers and adapted with Workbench-specific paths.
+- `using-workbench`: Trimmed meta-skill that announces what Workbench ships and resolves slug collisions in Workbench's favor. Defers core meta-rules to the upstream `using-superpowers` skill.
+
+## Coexistence
+
+Workbench is designed to run alongside the upstream `superpowers` plugin. When a slug exists in both plugins (today: `brainstorming`), prefer the Workbench version.
+
+The brainstorming skill's terminal handoff currently invokes `superpowers:writing-plans` cross-plugin. When `writing-plans` is later ported into Workbench, that reference will flip.
+
+## Credits
+
+This plugin includes content derived from the Superpowers plugin by Jesse Vincent (https://github.com/obra/superpowers), version 5.0.7, MIT-licensed. See the NOTICE file for the full list of derived files and the LICENSE file for the upstream license text.

--- a/plugins/workbench/hooks.json
+++ b/plugins/workbench/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./hooks/session-start"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workbench/hooks/hooks.json
+++ b/plugins/workbench/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workbench/hooks/run-hook.cmd
+++ b/plugins/workbench/hooks/run-hook.cmd
@@ -1,0 +1,46 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without SessionStart context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/plugins/workbench/hooks/session-start
+++ b/plugins/workbench/hooks/session-start
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SessionStart hook for workbench plugin
+
+set -euo pipefail
+
+# Determine plugin root directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Read using-workbench content
+using_workbench_content=$(cat "${PLUGIN_ROOT}/skills/using-workbench/SKILL.md" 2>&1 || echo "Error reading using-workbench skill")
+
+# Escape string for JSON embedding using bash parameter substitution.
+# Each ${s//old/new} is a single C-level pass - orders of magnitude
+# faster than the character-by-character loop this replaces.
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+using_workbench_escaped=$(escape_for_json "$using_workbench_content")
+session_context="<EXTREMELY_IMPORTANT>\nYou have workbench skills.\n\n**Below is the full content of your 'workbench:using-workbench' skill, your introduction to using Workbench skills alongside the upstream Superpowers meta-rules. For all other skills, use the 'Skill' tool:**\n\n${using_workbench_escaped}\n</EXTREMELY_IMPORTANT>"
+
+# Output context injection as JSON.
+# Cursor hooks expect additional_context (snake_case).
+# Claude Code hooks expect hookSpecificOutput.additionalContext (nested).
+# Copilot CLI (v1.0.11+) and others expect additionalContext (top-level, SDK standard).
+# Claude Code reads BOTH additional_context and hookSpecificOutput without
+# deduplication, so we must emit only the field the current platform consumes.
+#
+# Uses printf instead of heredoc to work around bash 5.3+ heredoc hang.
+# See: https://github.com/obra/superpowers/issues/571
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+  # Cursor sets CURSOR_PLUGIN_ROOT (may also set CLAUDE_PLUGIN_ROOT)
+  printf '{\n  "additional_context": "%s"\n}\n' "$session_context"
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+  # Claude Code sets CLAUDE_PLUGIN_ROOT without COPILOT_CLI
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$session_context"
+else
+  # Copilot CLI (sets COPILOT_CLI=1) or unknown platform — SDK standard format
+  printf '{\n  "additionalContext": "%s"\n}\n' "$session_context"
+fi
+
+exit 0

--- a/plugins/workbench/skills/brainstorming/SKILL.md
+++ b/plugins/workbench/skills/brainstorming/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: brainstorming
+description: "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+---
+
+# Brainstorming Ideas Into Designs
+
+Help turn ideas into fully formed designs and specs through natural collaborative dialogue.
+
+Start by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A todo list, a single-function utility, a config change — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## Checklist
+
+You MUST create a task for each of these items and complete them in order:
+
+1. **Explore project context** — check files, docs, recent commits
+2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
+3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+4. **Propose 2-3 approaches** — with trade-offs and your recommendation
+5. **Present design** — in sections scaled to their complexity, get user approval after each section
+6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+8. **User reviews written spec** — ask user to review the spec file before proceeding
+9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Explore project context" [shape=box];
+    "Visual questions ahead?" [shape=diamond];
+    "Offer Visual Companion\n(own message, no other content)" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design sections" [shape=box];
+    "User approves design?" [shape=diamond];
+    "Write design doc" [shape=box];
+    "Spec self-review\n(fix inline)" [shape=box];
+    "User reviews spec?" [shape=diamond];
+    "Invoke writing-plans skill" [shape=doublecircle];
+
+    "Explore project context" -> "Visual questions ahead?";
+    "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
+    "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
+    "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design sections";
+    "Present design sections" -> "User approves design?";
+    "User approves design?" -> "Present design sections" [label="no, revise"];
+    "User approves design?" -> "Write design doc" [label="yes"];
+    "Write design doc" -> "Spec self-review\n(fix inline)";
+    "Spec self-review\n(fix inline)" -> "User reviews spec?";
+    "User reviews spec?" -> "Write design doc" [label="changes requested"];
+    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+}
+```
+
+**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+
+## The Process
+
+**Understanding the idea:**
+
+- Check out the current project state first (files, docs, recent commits)
+- Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
+- If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
+- For appropriately-scoped projects, ask questions one at a time to refine the idea
+- Prefer multiple choice questions when possible, but open-ended is fine too
+- Only one question per message - if a topic needs more exploration, break it into multiple questions
+- Focus on understanding: purpose, constraints, success criteria
+
+**Exploring approaches:**
+
+- Propose 2-3 different approaches with trade-offs
+- Present options conversationally with your recommendation and reasoning
+- Lead with your recommended option and explain why
+
+**Presenting the design:**
+
+- Once you believe you understand what you're building, present the design
+- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced
+- Ask after each section whether it looks right so far
+- Cover: architecture, components, data flow, error handling, testing
+- Be ready to go back and clarify if something doesn't make sense
+
+**Design for isolation and clarity:**
+
+- Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently
+- For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?
+- Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.
+- Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.
+
+**Working in existing codebases:**
+
+- Explore the current structure before proposing changes. Follow existing patterns.
+- Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
+- Don't propose unrelated refactoring. Stay focused on what serves the current goal.
+
+## After the Design
+
+**Documentation:**
+
+- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+  - (User preferences for spec location override this default)
+- Use elements-of-style:writing-clearly-and-concisely skill if available
+- Commit the design document to git
+
+**Spec Self-Review:**
+After writing the spec document, look at it with fresh eyes:
+
+1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
+2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
+3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
+4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+
+Fix any issues inline. No need to re-review — just fix and move on.
+
+**User Review Gate:**
+After the spec review loop passes, ask the user to review the written spec before proceeding:
+
+> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+
+Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+
+**Implementation:**
+
+- Invoke the writing-plans skill to create a detailed implementation plan
+- Do NOT invoke any other skill. writing-plans is the next step.
+
+## Key Principles
+
+- **One question at a time** - Don't overwhelm with multiple questions
+- **Multiple choice preferred** - Easier to answer than open-ended when possible
+- **YAGNI ruthlessly** - Remove unnecessary features from all designs
+- **Explore alternatives** - Always propose 2-3 approaches before settling
+- **Incremental validation** - Present design, get approval before moving on
+- **Be flexible** - Go back and clarify when something doesn't make sense
+
+## Visual Companion
+
+A browser-based companion for showing mockups, diagrams, and visual options during brainstorming. Available as a tool — not a mode. Accepting the companion means it's available for questions that benefit from visual treatment; it does NOT mean every question goes through the browser.
+
+**Offering the companion:** When you anticipate that upcoming questions will involve visual content (mockups, layouts, diagrams), offer it once for consent:
+> "Some of what we're working on might be easier to explain if I can show it to you in a web browser. I can put together mockups, diagrams, comparisons, and other visuals as we go. This feature is still new and can be token-intensive. Want to try it? (Requires opening a local URL)"
+
+**This offer MUST be its own message.** Do not combine it with clarifying questions, context summaries, or any other content. The message should contain ONLY the offer above and nothing else. Wait for the user's response before continuing. If they decline, proceed with text-only brainstorming.
+
+**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**
+
+- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs
+- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions
+
+A question about a UI topic is not automatically a visual question. "What does personality mean in this context?" is a conceptual question — use the terminal. "Which wizard layout works better?" is a visual question — use the browser.
+
+If they agree to the companion, read the detailed guide before proceeding:
+`skills/brainstorming/visual-companion.md`

--- a/plugins/workbench/skills/brainstorming/SKILL.md
+++ b/plugins/workbench/skills/brainstorming/SKILL.md
@@ -21,13 +21,13 @@ Every project goes through this process. A todo list, a single-function utility,
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Explore project context** — check files, docs, recent commits
+1. **Explore project context** — dispatch a cost-efficient subagent to survey files, docs, and recent commits; use its summary as starting context
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
 6. **Write design doc** — save to `docs/workbench/specs/YYYY-MM-DD-<topic>-design.md` and commit
-7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
+7. **Spec self-review** — dispatch a reviewer subagent (host model inherits), then fix in place from its report (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
 9. **Transition to implementation** — invoke `superpowers:writing-plans` skill to create implementation plan
 
@@ -69,7 +69,7 @@ digraph brainstorming {
 
 **Understanding the idea:**
 
-- Check out the current project state first (files, docs, recent commits)
+- Delegate project-state exploration to a cost-efficient subagent (Claude Code: `Explore` agent type, haiku model. Codex: read-only research agent equivalent.) Pass a tight prompt: "Survey this repo. Report under 250 words: primary language, top-level structure, recent commits (last 5), presence of CLAUDE.md/AGENTS.md/README, any docs/ directory worth reading. Don't list every file." Use the returned summary as your starting context, do not read files yourself in the main session for this step.
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
@@ -100,7 +100,7 @@ digraph brainstorming {
 
 **Working in existing codebases:**
 
-- Explore the current structure before proposing changes. Follow existing patterns.
+- Delegate exploration of existing structure to a cost-efficient subagent (Claude Code: `Explore` agent type, haiku model. Codex: read-only research agent equivalent.) Pass a tight prompt scoped to the area you're touching: "Survey [path or subsystem]. Report under 250 words: existing patterns and conventions, naming, key entry points, files that change together, any clearly-overgrown files. Don't list every file." Follow the returned conventions when proposing changes.
 - Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.
 - Don't propose unrelated refactoring. Stay focused on what serves the current goal.
 
@@ -114,14 +114,18 @@ digraph brainstorming {
 - Commit the design document to git
 
 **Spec Self-Review:**
-After writing the spec document, look at it with fresh eyes:
+After writing the spec document, dispatch a reviewer subagent that has not seen the brainstorming conversation. Pass the spec file path and the four checks below; the subagent reports findings, you fix in place.
 
-1. **Placeholder scan:** Any "TBD", "TODO", incomplete sections, or vague requirements? Fix them.
-2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?
-3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?
-4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.
+Use a general-purpose subagent (Claude Code: `Agent` tool with `general-purpose` subagent_type. Codex: equivalent general-purpose subagent.) Do not specify a model override; the subagent inherits the host session's model so review depth matches your own.
 
-Fix any issues inline. No need to re-review — just fix and move on.
+The reviewer's checks:
+
+1. **Placeholder scan:** any "TBD", "TODO", incomplete sections, or vague requirements?
+2. **Internal consistency:** do any sections contradict each other? Does the architecture match the feature descriptions?
+3. **Scope check:** is this focused enough for a single implementation plan, or does it need decomposition?
+4. **Ambiguity check:** could any requirement be interpreted two different ways? If so, which interpretation should be made explicit?
+
+Why a separate subagent: "fresh eyes" means literally not having seen the dialogue or the writing. After the report comes back, fix any issues inline in the spec document. No re-review needed; fix and move on.
 
 **User Review Gate:**
 After the spec review loop passes, ask the user to review the written spec before proceeding:

--- a/plugins/workbench/skills/brainstorming/SKILL.md
+++ b/plugins/workbench/skills/brainstorming/SKILL.md
@@ -26,10 +26,10 @@ You MUST create a task for each of these items and complete them in order:
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
-6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
+6. **Write design doc** — save to `docs/workbench/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+9. **Transition to implementation** — invoke `superpowers:writing-plans` skill to create implementation plan
 
 ## Process Flow
 
@@ -45,7 +45,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "User reviews spec?" [shape=diamond];
-    "Invoke writing-plans skill" [shape=doublecircle];
+    "Invoke superpowers:writing-plans skill" [shape=doublecircle];
 
     "Explore project context" -> "Visual questions ahead?";
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
@@ -59,11 +59,11 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "User reviews spec?";
     "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User reviews spec?" -> "Invoke superpowers:writing-plans skill" [label="approved"];
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.
+**The terminal state is invoking `superpowers:writing-plans`.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is `superpowers:writing-plans`.
 
 ## The Process
 
@@ -108,7 +108,7 @@ digraph brainstorming {
 
 **Documentation:**
 
-- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- Write the validated design (spec) to `docs/workbench/specs/YYYY-MM-DD-<topic>-design.md`
   - (User preferences for spec location override this default)
 - Use elements-of-style:writing-clearly-and-concisely skill if available
 - Commit the design document to git
@@ -132,8 +132,8 @@ Wait for the user's response. If they request changes, make them and re-run the 
 
 **Implementation:**
 
-- Invoke the writing-plans skill to create a detailed implementation plan
-- Do NOT invoke any other skill. writing-plans is the next step.
+- Invoke the `superpowers:writing-plans` skill to create a detailed implementation plan
+- Do NOT invoke any other skill. `superpowers:writing-plans` is the next step. (When `writing-plans` is later ported into Workbench, this reference flips to `workbench:writing-plans`.)
 
 ## Key Principles
 

--- a/plugins/workbench/skills/brainstorming/scripts/frame-template.html
+++ b/plugins/workbench/skills/brainstorming/scripts/frame-template.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Superpowers Brainstorming</title>
+  <title>Workbench Brainstorming</title>
   <style>
     /*
      * BRAINSTORM COMPANION FRAME TEMPLATE
@@ -196,7 +196,7 @@
 </head>
 <body>
   <div class="header">
-    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+    <h1><a href="https://github.com/pgoell/pgoell-claude-tools" style="color: inherit; text-decoration: none;">Workbench Brainstorming</a></h1>
     <div class="status">Connected</div>
   </div>
 

--- a/plugins/workbench/skills/brainstorming/scripts/frame-template.html
+++ b/plugins/workbench/skills/brainstorming/scripts/frame-template.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Superpowers Brainstorming</title>
+  <style>
+    /*
+     * BRAINSTORM COMPANION FRAME TEMPLATE
+     *
+     * This template provides a consistent frame with:
+     * - OS-aware light/dark theming
+     * - Fixed header and selection indicator bar
+     * - Scrollable main content area
+     * - CSS helpers for common UI patterns
+     *
+     * Content is injected via placeholder comment in #claude-content.
+     */
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+
+    /* ===== THEME VARIABLES ===== */
+    :root {
+      --bg-primary: #f5f5f7;
+      --bg-secondary: #ffffff;
+      --bg-tertiary: #e5e5e7;
+      --border: #d1d1d6;
+      --text-primary: #1d1d1f;
+      --text-secondary: #86868b;
+      --text-tertiary: #aeaeb2;
+      --accent: #0071e3;
+      --accent-hover: #0077ed;
+      --success: #34c759;
+      --warning: #ff9f0a;
+      --error: #ff3b30;
+      --selected-bg: #e8f4fd;
+      --selected-border: #0071e3;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #1d1d1f;
+        --bg-secondary: #2d2d2f;
+        --bg-tertiary: #3d3d3f;
+        --border: #424245;
+        --text-primary: #f5f5f7;
+        --text-secondary: #86868b;
+        --text-tertiary: #636366;
+        --accent: #0a84ff;
+        --accent-hover: #409cff;
+        --selected-bg: rgba(10, 132, 255, 0.15);
+        --selected-border: #0a84ff;
+      }
+    }
+
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      display: flex;
+      flex-direction: column;
+      line-height: 1.5;
+    }
+
+    /* ===== FRAME STRUCTURE ===== */
+    .header {
+      background: var(--bg-secondary);
+      padding: 0.5rem 1.5rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .header h1 { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); }
+    .header .status { font-size: 0.7rem; color: var(--success); display: flex; align-items: center; gap: 0.4rem; }
+    .header .status::before { content: ''; width: 6px; height: 6px; background: var(--success); border-radius: 50%; }
+
+    .main { flex: 1; overflow-y: auto; }
+    #claude-content { padding: 2rem; min-height: 100%; }
+
+    .indicator-bar {
+      background: var(--bg-secondary);
+      border-top: 1px solid var(--border);
+      padding: 0.5rem 1.5rem;
+      flex-shrink: 0;
+      text-align: center;
+    }
+    .indicator-bar span {
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+    .indicator-bar .selected-text {
+      color: var(--accent);
+      font-weight: 500;
+    }
+
+    /* ===== TYPOGRAPHY ===== */
+    h2 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
+    h3 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.25rem; }
+    .subtitle { color: var(--text-secondary); margin-bottom: 1.5rem; }
+    .section { margin-bottom: 2rem; }
+    .label { font-size: 0.7rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.5rem; }
+
+    /* ===== OPTIONS (for A/B/C choices) ===== */
+    .options { display: flex; flex-direction: column; gap: 0.75rem; }
+    .option {
+      background: var(--bg-secondary);
+      border: 2px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      display: flex;
+      align-items: flex-start;
+      gap: 1rem;
+    }
+    .option:hover { border-color: var(--accent); }
+    .option.selected { background: var(--selected-bg); border-color: var(--selected-border); }
+    .option .letter {
+      background: var(--bg-tertiary);
+      color: var(--text-secondary);
+      width: 1.75rem; height: 1.75rem;
+      border-radius: 6px;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 600; font-size: 0.85rem; flex-shrink: 0;
+    }
+    .option.selected .letter { background: var(--accent); color: white; }
+    .option .content { flex: 1; }
+    .option .content h3 { font-size: 0.95rem; margin-bottom: 0.15rem; }
+    .option .content p { color: var(--text-secondary); font-size: 0.85rem; margin: 0; }
+
+    /* ===== CARDS (for showing designs/mockups) ===== */
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+    .card {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+    .card:hover { border-color: var(--accent); transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+    .card.selected { border-color: var(--selected-border); border-width: 2px; }
+    .card-image { background: var(--bg-tertiary); aspect-ratio: 16/10; display: flex; align-items: center; justify-content: center; }
+    .card-body { padding: 1rem; }
+    .card-body h3 { margin-bottom: 0.25rem; }
+    .card-body p { color: var(--text-secondary); font-size: 0.85rem; }
+
+    /* ===== MOCKUP CONTAINER ===== */
+    .mockup {
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 1.5rem;
+    }
+    .mockup-header {
+      background: var(--bg-tertiary);
+      padding: 0.5rem 1rem;
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+      border-bottom: 1px solid var(--border);
+    }
+    .mockup-body { padding: 1.5rem; }
+
+    /* ===== SPLIT VIEW (side-by-side comparison) ===== */
+    .split { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+    @media (max-width: 700px) { .split { grid-template-columns: 1fr; } }
+
+    /* ===== PROS/CONS ===== */
+    .pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1rem 0; }
+    .pros, .cons { background: var(--bg-secondary); border-radius: 8px; padding: 1rem; }
+    .pros h4 { color: var(--success); font-size: 0.85rem; margin-bottom: 0.5rem; }
+    .cons h4 { color: var(--error); font-size: 0.85rem; margin-bottom: 0.5rem; }
+    .pros ul, .cons ul { margin-left: 1.25rem; font-size: 0.85rem; color: var(--text-secondary); }
+    .pros li, .cons li { margin-bottom: 0.25rem; }
+
+    /* ===== PLACEHOLDER (for mockup areas) ===== */
+    .placeholder {
+      background: var(--bg-tertiary);
+      border: 2px dashed var(--border);
+      border-radius: 8px;
+      padding: 2rem;
+      text-align: center;
+      color: var(--text-tertiary);
+    }
+
+    /* ===== INLINE MOCKUP ELEMENTS ===== */
+    .mock-nav { background: var(--accent); color: white; padding: 0.75rem 1rem; display: flex; gap: 1.5rem; font-size: 0.9rem; }
+    .mock-sidebar { background: var(--bg-tertiary); padding: 1rem; min-width: 180px; }
+    .mock-content { padding: 1.5rem; flex: 1; }
+    .mock-button { background: var(--accent); color: white; border: none; padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.85rem; }
+    .mock-input { background: var(--bg-primary); border: 1px solid var(--border); border-radius: 6px; padding: 0.5rem; width: 100%; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h1><a href="https://github.com/obra/superpowers" style="color: inherit; text-decoration: none;">Superpowers Brainstorming</a></h1>
+    <div class="status">Connected</div>
+  </div>
+
+  <div class="main">
+    <div id="claude-content">
+      <!-- CONTENT -->
+    </div>
+  </div>
+
+  <div class="indicator-bar">
+    <span id="indicator-text">Click an option above, then return to the terminal</span>
+  </div>
+
+</body>
+</html>

--- a/plugins/workbench/skills/brainstorming/scripts/helper.js
+++ b/plugins/workbench/skills/brainstorming/scripts/helper.js
@@ -1,0 +1,88 @@
+(function() {
+  const WS_URL = 'ws://' + window.location.host;
+  let ws = null;
+  let eventQueue = [];
+
+  function connect() {
+    ws = new WebSocket(WS_URL);
+
+    ws.onopen = () => {
+      eventQueue.forEach(e => ws.send(JSON.stringify(e)));
+      eventQueue = [];
+    };
+
+    ws.onmessage = (msg) => {
+      const data = JSON.parse(msg.data);
+      if (data.type === 'reload') {
+        window.location.reload();
+      }
+    };
+
+    ws.onclose = () => {
+      setTimeout(connect, 1000);
+    };
+  }
+
+  function sendEvent(event) {
+    event.timestamp = Date.now();
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(event));
+    } else {
+      eventQueue.push(event);
+    }
+  }
+
+  // Capture clicks on choice elements
+  document.addEventListener('click', (e) => {
+    const target = e.target.closest('[data-choice]');
+    if (!target) return;
+
+    sendEvent({
+      type: 'click',
+      text: target.textContent.trim(),
+      choice: target.dataset.choice,
+      id: target.id || null
+    });
+
+    // Update indicator bar (defer so toggleSelect runs first)
+    setTimeout(() => {
+      const indicator = document.getElementById('indicator-text');
+      if (!indicator) return;
+      const container = target.closest('.options') || target.closest('.cards');
+      const selected = container ? container.querySelectorAll('.selected') : [];
+      if (selected.length === 0) {
+        indicator.textContent = 'Click an option above, then return to the terminal';
+      } else if (selected.length === 1) {
+        const label = selected[0].querySelector('h3, .content h3, .card-body h3')?.textContent?.trim() || selected[0].dataset.choice;
+        indicator.innerHTML = '<span class="selected-text">' + label + ' selected</span> — return to terminal to continue';
+      } else {
+        indicator.innerHTML = '<span class="selected-text">' + selected.length + ' selected</span> — return to terminal to continue';
+      }
+    }, 0);
+  });
+
+  // Frame UI: selection tracking
+  window.selectedChoice = null;
+
+  window.toggleSelect = function(el) {
+    const container = el.closest('.options') || el.closest('.cards');
+    const multi = container && container.dataset.multiselect !== undefined;
+    if (container && !multi) {
+      container.querySelectorAll('.option, .card').forEach(o => o.classList.remove('selected'));
+    }
+    if (multi) {
+      el.classList.toggle('selected');
+    } else {
+      el.classList.add('selected');
+    }
+    window.selectedChoice = el.dataset.choice;
+  };
+
+  // Expose API for explicit use
+  window.brainstorm = {
+    send: sendEvent,
+    choice: (value, metadata = {}) => sendEvent({ type: 'choice', value, ...metadata })
+  };
+
+  connect();
+})();

--- a/plugins/workbench/skills/brainstorming/scripts/server.cjs
+++ b/plugins/workbench/skills/brainstorming/scripts/server.cjs
@@ -1,0 +1,354 @@
+const crypto = require('crypto');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+// ========== WebSocket Protocol (RFC 6455) ==========
+
+const OPCODES = { TEXT: 0x01, CLOSE: 0x08, PING: 0x09, PONG: 0x0A };
+const WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+function computeAcceptKey(clientKey) {
+  return crypto.createHash('sha1').update(clientKey + WS_MAGIC).digest('base64');
+}
+
+function encodeFrame(opcode, payload) {
+  const fin = 0x80;
+  const len = payload.length;
+  let header;
+
+  if (len < 126) {
+    header = Buffer.alloc(2);
+    header[0] = fin | opcode;
+    header[1] = len;
+  } else if (len < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = fin | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = fin | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+
+  return Buffer.concat([header, payload]);
+}
+
+function decodeFrame(buffer) {
+  if (buffer.length < 2) return null;
+
+  const secondByte = buffer[1];
+  const opcode = buffer[0] & 0x0F;
+  const masked = (secondByte & 0x80) !== 0;
+  let payloadLen = secondByte & 0x7F;
+  let offset = 2;
+
+  if (!masked) throw new Error('Client frames must be masked');
+
+  if (payloadLen === 126) {
+    if (buffer.length < 4) return null;
+    payloadLen = buffer.readUInt16BE(2);
+    offset = 4;
+  } else if (payloadLen === 127) {
+    if (buffer.length < 10) return null;
+    payloadLen = Number(buffer.readBigUInt64BE(2));
+    offset = 10;
+  }
+
+  const maskOffset = offset;
+  const dataOffset = offset + 4;
+  const totalLen = dataOffset + payloadLen;
+  if (buffer.length < totalLen) return null;
+
+  const mask = buffer.slice(maskOffset, dataOffset);
+  const data = Buffer.alloc(payloadLen);
+  for (let i = 0; i < payloadLen; i++) {
+    data[i] = buffer[dataOffset + i] ^ mask[i % 4];
+  }
+
+  return { opcode, payload: data, bytesConsumed: totalLen };
+}
+
+// ========== Configuration ==========
+
+const PORT = process.env.BRAINSTORM_PORT || (49152 + Math.floor(Math.random() * 16383));
+const HOST = process.env.BRAINSTORM_HOST || '127.0.0.1';
+const URL_HOST = process.env.BRAINSTORM_URL_HOST || (HOST === '127.0.0.1' ? 'localhost' : HOST);
+const SESSION_DIR = process.env.BRAINSTORM_DIR || '/tmp/brainstorm';
+const CONTENT_DIR = path.join(SESSION_DIR, 'content');
+const STATE_DIR = path.join(SESSION_DIR, 'state');
+let ownerPid = process.env.BRAINSTORM_OWNER_PID ? Number(process.env.BRAINSTORM_OWNER_PID) : null;
+
+const MIME_TYPES = {
+  '.html': 'text/html', '.css': 'text/css', '.js': 'application/javascript',
+  '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.svg': 'image/svg+xml'
+};
+
+// ========== Templates and Constants ==========
+
+const WAITING_PAGE = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Brainstorm Companion</title>
+<style>body { font-family: system-ui, sans-serif; padding: 2rem; max-width: 800px; margin: 0 auto; }
+h1 { color: #333; } p { color: #666; }</style>
+</head>
+<body><h1>Brainstorm Companion</h1>
+<p>Waiting for the agent to push a screen...</p></body></html>`;
+
+const frameTemplate = fs.readFileSync(path.join(__dirname, 'frame-template.html'), 'utf-8');
+const helperScript = fs.readFileSync(path.join(__dirname, 'helper.js'), 'utf-8');
+const helperInjection = '<script>\n' + helperScript + '\n</script>';
+
+// ========== Helper Functions ==========
+
+function isFullDocument(html) {
+  const trimmed = html.trimStart().toLowerCase();
+  return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
+}
+
+function wrapInFrame(content) {
+  return frameTemplate.replace('<!-- CONTENT -->', content);
+}
+
+function getNewestScreen() {
+  const files = fs.readdirSync(CONTENT_DIR)
+    .filter(f => f.endsWith('.html'))
+    .map(f => {
+      const fp = path.join(CONTENT_DIR, f);
+      return { path: fp, mtime: fs.statSync(fp).mtime.getTime() };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+  return files.length > 0 ? files[0].path : null;
+}
+
+// ========== HTTP Request Handler ==========
+
+function handleRequest(req, res) {
+  touchActivity();
+  if (req.method === 'GET' && req.url === '/') {
+    const screenFile = getNewestScreen();
+    let html = screenFile
+      ? (raw => isFullDocument(raw) ? raw : wrapInFrame(raw))(fs.readFileSync(screenFile, 'utf-8'))
+      : WAITING_PAGE;
+
+    if (html.includes('</body>')) {
+      html = html.replace('</body>', helperInjection + '\n</body>');
+    } else {
+      html += helperInjection;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(html);
+  } else if (req.method === 'GET' && req.url.startsWith('/files/')) {
+    const fileName = req.url.slice(7);
+    const filePath = path.join(CONTENT_DIR, path.basename(fileName));
+    if (!fs.existsSync(filePath)) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(fs.readFileSync(filePath));
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}
+
+// ========== WebSocket Connection Handling ==========
+
+const clients = new Set();
+
+function handleUpgrade(req, socket) {
+  const key = req.headers['sec-websocket-key'];
+  if (!key) { socket.destroy(); return; }
+
+  const accept = computeAcceptKey(key);
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    'Sec-WebSocket-Accept: ' + accept + '\r\n\r\n'
+  );
+
+  let buffer = Buffer.alloc(0);
+  clients.add(socket);
+
+  socket.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length > 0) {
+      let result;
+      try {
+        result = decodeFrame(buffer);
+      } catch (e) {
+        socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
+        clients.delete(socket);
+        return;
+      }
+      if (!result) break;
+      buffer = buffer.slice(result.bytesConsumed);
+
+      switch (result.opcode) {
+        case OPCODES.TEXT:
+          handleMessage(result.payload.toString());
+          break;
+        case OPCODES.CLOSE:
+          socket.end(encodeFrame(OPCODES.CLOSE, Buffer.alloc(0)));
+          clients.delete(socket);
+          return;
+        case OPCODES.PING:
+          socket.write(encodeFrame(OPCODES.PONG, result.payload));
+          break;
+        case OPCODES.PONG:
+          break;
+        default: {
+          const closeBuf = Buffer.alloc(2);
+          closeBuf.writeUInt16BE(1003);
+          socket.end(encodeFrame(OPCODES.CLOSE, closeBuf));
+          clients.delete(socket);
+          return;
+        }
+      }
+    }
+  });
+
+  socket.on('close', () => clients.delete(socket));
+  socket.on('error', () => clients.delete(socket));
+}
+
+function handleMessage(text) {
+  let event;
+  try {
+    event = JSON.parse(text);
+  } catch (e) {
+    console.error('Failed to parse WebSocket message:', e.message);
+    return;
+  }
+  touchActivity();
+  console.log(JSON.stringify({ source: 'user-event', ...event }));
+  if (event.choice) {
+    const eventsFile = path.join(STATE_DIR, 'events');
+    fs.appendFileSync(eventsFile, JSON.stringify(event) + '\n');
+  }
+}
+
+function broadcast(msg) {
+  const frame = encodeFrame(OPCODES.TEXT, Buffer.from(JSON.stringify(msg)));
+  for (const socket of clients) {
+    try { socket.write(frame); } catch (e) { clients.delete(socket); }
+  }
+}
+
+// ========== Activity Tracking ==========
+
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+let lastActivity = Date.now();
+
+function touchActivity() {
+  lastActivity = Date.now();
+}
+
+// ========== File Watching ==========
+
+const debounceTimers = new Map();
+
+// ========== Server Startup ==========
+
+function startServer() {
+  if (!fs.existsSync(CONTENT_DIR)) fs.mkdirSync(CONTENT_DIR, { recursive: true });
+  if (!fs.existsSync(STATE_DIR)) fs.mkdirSync(STATE_DIR, { recursive: true });
+
+  // Track known files to distinguish new screens from updates.
+  // macOS fs.watch reports 'rename' for both new files and overwrites,
+  // so we can't rely on eventType alone.
+  const knownFiles = new Set(
+    fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.html'))
+  );
+
+  const server = http.createServer(handleRequest);
+  server.on('upgrade', handleUpgrade);
+
+  const watcher = fs.watch(CONTENT_DIR, (eventType, filename) => {
+    if (!filename || !filename.endsWith('.html')) return;
+
+    if (debounceTimers.has(filename)) clearTimeout(debounceTimers.get(filename));
+    debounceTimers.set(filename, setTimeout(() => {
+      debounceTimers.delete(filename);
+      const filePath = path.join(CONTENT_DIR, filename);
+
+      if (!fs.existsSync(filePath)) return; // file was deleted
+      touchActivity();
+
+      if (!knownFiles.has(filename)) {
+        knownFiles.add(filename);
+        const eventsFile = path.join(STATE_DIR, 'events');
+        if (fs.existsSync(eventsFile)) fs.unlinkSync(eventsFile);
+        console.log(JSON.stringify({ type: 'screen-added', file: filePath }));
+      } else {
+        console.log(JSON.stringify({ type: 'screen-updated', file: filePath }));
+      }
+
+      broadcast({ type: 'reload' });
+    }, 100));
+  });
+  watcher.on('error', (err) => console.error('fs.watch error:', err.message));
+
+  function shutdown(reason) {
+    console.log(JSON.stringify({ type: 'server-stopped', reason }));
+    const infoFile = path.join(STATE_DIR, 'server-info');
+    if (fs.existsSync(infoFile)) fs.unlinkSync(infoFile);
+    fs.writeFileSync(
+      path.join(STATE_DIR, 'server-stopped'),
+      JSON.stringify({ reason, timestamp: Date.now() }) + '\n'
+    );
+    watcher.close();
+    clearInterval(lifecycleCheck);
+    server.close(() => process.exit(0));
+  }
+
+  function ownerAlive() {
+    if (!ownerPid) return true;
+    try { process.kill(ownerPid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+  }
+
+  // Check every 60s: exit if owner process died or idle for 30 minutes
+  const lifecycleCheck = setInterval(() => {
+    if (!ownerAlive()) shutdown('owner process exited');
+    else if (Date.now() - lastActivity > IDLE_TIMEOUT_MS) shutdown('idle timeout');
+  }, 60 * 1000);
+  lifecycleCheck.unref();
+
+  // Validate owner PID at startup. If it's already dead, the PID resolution
+  // was wrong (common on WSL, Tailscale SSH, and cross-user scenarios).
+  // Disable monitoring and rely on the idle timeout instead.
+  if (ownerPid) {
+    try { process.kill(ownerPid, 0); }
+    catch (e) {
+      if (e.code !== 'EPERM') {
+        console.log(JSON.stringify({ type: 'owner-pid-invalid', pid: ownerPid, reason: 'dead at startup' }));
+        ownerPid = null;
+      }
+    }
+  }
+
+  server.listen(PORT, HOST, () => {
+    const info = JSON.stringify({
+      type: 'server-started', port: Number(PORT), host: HOST,
+      url_host: URL_HOST, url: 'http://' + URL_HOST + ':' + PORT,
+      screen_dir: CONTENT_DIR, state_dir: STATE_DIR
+    });
+    console.log(info);
+    fs.writeFileSync(path.join(STATE_DIR, 'server-info'), info + '\n');
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { computeAcceptKey, encodeFrame, decodeFrame, OPCODES };

--- a/plugins/workbench/skills/brainstorming/scripts/start-server.sh
+++ b/plugins/workbench/skills/brainstorming/scripts/start-server.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Start the brainstorm server and output connection info
+# Usage: start-server.sh [--project-dir <path>] [--host <bind-host>] [--url-host <display-host>] [--foreground] [--background]
+#
+# Starts server on a random high port, outputs JSON with URL.
+# Each session gets its own directory to avoid conflicts.
+#
+# Options:
+#   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
+#                         instead of /tmp. Files persist after server stops.
+#   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
+#                         Use 0.0.0.0 in remote/containerized environments.
+#   --url-host <host>     Hostname shown in returned URL JSON.
+#   --foreground          Run server in the current terminal (no backgrounding).
+#   --background          Force background mode (overrides Codex auto-foreground).
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Parse arguments
+PROJECT_DIR=""
+FOREGROUND="false"
+FORCE_BACKGROUND="false"
+BIND_HOST="127.0.0.1"
+URL_HOST=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-dir)
+      PROJECT_DIR="$2"
+      shift 2
+      ;;
+    --host)
+      BIND_HOST="$2"
+      shift 2
+      ;;
+    --url-host)
+      URL_HOST="$2"
+      shift 2
+      ;;
+    --foreground|--no-daemon)
+      FOREGROUND="true"
+      shift
+      ;;
+    --background|--daemon)
+      FORCE_BACKGROUND="true"
+      shift
+      ;;
+    *)
+      echo "{\"error\": \"Unknown argument: $1\"}"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$URL_HOST" ]]; then
+  if [[ "$BIND_HOST" == "127.0.0.1" || "$BIND_HOST" == "localhost" ]]; then
+    URL_HOST="localhost"
+  else
+    URL_HOST="$BIND_HOST"
+  fi
+fi
+
+# Some environments reap detached/background processes. Auto-foreground when detected.
+if [[ -n "${CODEX_CI:-}" && "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  FOREGROUND="true"
+fi
+
+# Windows/Git Bash reaps nohup background processes. Auto-foreground when detected.
+if [[ "$FOREGROUND" != "true" && "$FORCE_BACKGROUND" != "true" ]]; then
+  case "${OSTYPE:-}" in
+    msys*|cygwin*|mingw*) FOREGROUND="true" ;;
+  esac
+  if [[ -n "${MSYSTEM:-}" ]]; then
+    FOREGROUND="true"
+  fi
+fi
+
+# Generate unique session directory
+SESSION_ID="$$-$(date +%s)"
+
+if [[ -n "$PROJECT_DIR" ]]; then
+  SESSION_DIR="${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}"
+else
+  SESSION_DIR="/tmp/brainstorm-${SESSION_ID}"
+fi
+
+STATE_DIR="${SESSION_DIR}/state"
+PID_FILE="${STATE_DIR}/server.pid"
+LOG_FILE="${STATE_DIR}/server.log"
+
+# Create fresh session directory with content and state peers
+mkdir -p "${SESSION_DIR}/content" "$STATE_DIR"
+
+# Kill any existing server
+if [[ -f "$PID_FILE" ]]; then
+  old_pid=$(cat "$PID_FILE")
+  kill "$old_pid" 2>/dev/null
+  rm -f "$PID_FILE"
+fi
+
+cd "$SCRIPT_DIR"
+
+# Resolve the harness PID (grandparent of this script).
+# $PPID is the ephemeral shell the harness spawned to run us — it dies
+# when this script exits. The harness itself is $PPID's parent.
+OWNER_PID="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d ' ')"
+if [[ -z "$OWNER_PID" || "$OWNER_PID" == "1" ]]; then
+  OWNER_PID="$PPID"
+fi
+
+# Foreground mode for environments that reap detached/background processes.
+if [[ "$FOREGROUND" == "true" ]]; then
+  echo "$$" > "$PID_FILE"
+  env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs
+  exit $?
+fi
+
+# Start server, capturing output to log file
+# Use nohup to survive shell exit; disown to remove from job table
+nohup env BRAINSTORM_DIR="$SESSION_DIR" BRAINSTORM_HOST="$BIND_HOST" BRAINSTORM_URL_HOST="$URL_HOST" BRAINSTORM_OWNER_PID="$OWNER_PID" node server.cjs > "$LOG_FILE" 2>&1 &
+SERVER_PID=$!
+disown "$SERVER_PID" 2>/dev/null
+echo "$SERVER_PID" > "$PID_FILE"
+
+# Wait for server-started message (check log file)
+for i in {1..50}; do
+  if grep -q "server-started" "$LOG_FILE" 2>/dev/null; then
+    # Verify server is still alive after a short window (catches process reapers)
+    alive="true"
+    for _ in {1..20}; do
+      if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        alive="false"
+        break
+      fi
+      sleep 0.1
+    done
+    if [[ "$alive" != "true" ]]; then
+      echo "{\"error\": \"Server started but was killed. Retry in a persistent terminal with: $SCRIPT_DIR/start-server.sh${PROJECT_DIR:+ --project-dir $PROJECT_DIR} --host $BIND_HOST --url-host $URL_HOST --foreground\"}"
+      exit 1
+    fi
+    grep "server-started" "$LOG_FILE" | head -1
+    exit 0
+  fi
+  sleep 0.1
+done
+
+# Timeout - server didn't start
+echo '{"error": "Server failed to start within 5 seconds"}'
+exit 1

--- a/plugins/workbench/skills/brainstorming/scripts/start-server.sh
+++ b/plugins/workbench/skills/brainstorming/scripts/start-server.sh
@@ -6,7 +6,7 @@
 # Each session gets its own directory to avoid conflicts.
 #
 # Options:
-#   --project-dir <path>  Store session files under <path>/.superpowers/brainstorm/
+#   --project-dir <path>  Store session files under <path>/.workbench/brainstorm/
 #                         instead of /tmp. Files persist after server stops.
 #   --host <bind-host>    Host/interface to bind (default: 127.0.0.1).
 #                         Use 0.0.0.0 in remote/containerized environments.
@@ -78,7 +78,7 @@ fi
 SESSION_ID="$$-$(date +%s)"
 
 if [[ -n "$PROJECT_DIR" ]]; then
-  SESSION_DIR="${PROJECT_DIR}/.superpowers/brainstorm/${SESSION_ID}"
+  SESSION_DIR="${PROJECT_DIR}/.workbench/brainstorm/${SESSION_ID}"
 else
   SESSION_DIR="/tmp/brainstorm-${SESSION_ID}"
 fi

--- a/plugins/workbench/skills/brainstorming/scripts/stop-server.sh
+++ b/plugins/workbench/skills/brainstorming/scripts/stop-server.sh
@@ -3,7 +3,7 @@
 # Usage: stop-server.sh <session_dir>
 #
 # Kills the server process. Only deletes session directory if it's
-# under /tmp (ephemeral). Persistent directories (.superpowers/) are
+# under /tmp (ephemeral). Persistent directories (.workbench/) are
 # kept so mockups can be reviewed later.
 
 SESSION_DIR="$1"

--- a/plugins/workbench/skills/brainstorming/scripts/stop-server.sh
+++ b/plugins/workbench/skills/brainstorming/scripts/stop-server.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Stop the brainstorm server and clean up
+# Usage: stop-server.sh <session_dir>
+#
+# Kills the server process. Only deletes session directory if it's
+# under /tmp (ephemeral). Persistent directories (.superpowers/) are
+# kept so mockups can be reviewed later.
+
+SESSION_DIR="$1"
+
+if [[ -z "$SESSION_DIR" ]]; then
+  echo '{"error": "Usage: stop-server.sh <session_dir>"}'
+  exit 1
+fi
+
+STATE_DIR="${SESSION_DIR}/state"
+PID_FILE="${STATE_DIR}/server.pid"
+
+if [[ -f "$PID_FILE" ]]; then
+  pid=$(cat "$PID_FILE")
+
+  # Try to stop gracefully, fallback to force if still alive
+  kill "$pid" 2>/dev/null || true
+
+  # Wait for graceful shutdown (up to ~2s)
+  for i in {1..20}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  # If still running, escalate to SIGKILL
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null || true
+
+    # Give SIGKILL a moment to take effect
+    sleep 0.1
+  fi
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo '{"status": "failed", "error": "process still running"}'
+    exit 1
+  fi
+
+  rm -f "$PID_FILE" "${STATE_DIR}/server.log"
+
+  # Only delete ephemeral /tmp directories
+  if [[ "$SESSION_DIR" == /tmp/* ]]; then
+    rm -rf "$SESSION_DIR"
+  fi
+
+  echo '{"status": "stopped"}'
+else
+  echo '{"status": "not_running"}'
+fi

--- a/plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Spec Document Reviewer Prompt Template
+
+Use this template when dispatching a spec document reviewer subagent.
+
+**Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
+
+**Dispatch after:** Spec document is written to docs/superpowers/specs/
+
+```
+Task tool (general-purpose):
+  description: "Review spec document"
+  prompt: |
+    You are a spec document reviewer. Verify this spec is complete and ready for planning.
+
+    **Spec to review:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, "TBD", incomplete sections |
+    | Consistency | Internal contradictions, conflicting requirements |
+    | Clarity | Requirements ambiguous enough to cause someone to build the wrong thing |
+    | Scope | Focused enough for a single plan — not covering multiple independent subsystems |
+    | YAGNI | Unrequested features, over-engineering |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation planning.**
+    A missing section, a contradiction, or a requirement so ambiguous it could be
+    interpreted two different ways — those are issues. Minor wording improvements,
+    stylistic preferences, and "sections less detailed than others" are not.
+
+    Approve unless there are serious gaps that would lead to a flawed plan.
+
+    ## Output Format
+
+    ## Spec Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Section X]: [specific issue] - [why it matters for planning]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations

--- a/plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md
+++ b/plugins/workbench/skills/brainstorming/spec-document-reviewer-prompt.md
@@ -4,7 +4,7 @@ Use this template when dispatching a spec document reviewer subagent.
 
 **Purpose:** Verify the spec is complete, consistent, and ready for implementation planning.
 
-**Dispatch after:** Spec document is written to docs/superpowers/specs/
+**Dispatch after:** Spec document is written to docs/workbench/specs/
 
 ```
 Task tool (general-purpose):

--- a/plugins/workbench/skills/brainstorming/visual-companion.md
+++ b/plugins/workbench/skills/brainstorming/visual-companion.md
@@ -37,15 +37,15 @@ The server watches a directory for HTML files and serves the newest one to the b
 scripts/start-server.sh --project-dir /path/to/project
 
 # Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
-#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
-#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+#           "screen_dir":"/path/to/project/.workbench/brainstorm/12345-1706000000/content",
+#           "state_dir":"/path/to/project/.workbench/brainstorm/12345-1706000000/state"}
 ```
 
 Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
 
-**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.workbench/brainstorm/` for the session directory.
 
-**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+**Note:** Pass the project root as `--project-dir` so mockups persist in `.workbench/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.workbench/` to `.gitignore` if it's not already there.
 
 **Launching the server by platform:**
 
@@ -279,7 +279,7 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 scripts/stop-server.sh $SESSION_DIR
 ```
 
-If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+If the session used `--project-dir`, mockup files persist in `.workbench/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
 
 ## Reference
 

--- a/plugins/workbench/skills/brainstorming/visual-companion.md
+++ b/plugins/workbench/skills/brainstorming/visual-companion.md
@@ -1,0 +1,287 @@
+# Visual Companion Guide
+
+Browser-based visual brainstorming companion for showing mockups, diagrams, and options.
+
+## When to Use
+
+Decide per-question, not per-session. The test: **would the user understand this better by seeing it than reading it?**
+
+**Use the browser** when the content itself is visual:
+
+- **UI mockups** — wireframes, layouts, navigation structures, component designs
+- **Architecture diagrams** — system components, data flow, relationship maps
+- **Side-by-side visual comparisons** — comparing two layouts, two color schemes, two design directions
+- **Design polish** — when the question is about look and feel, spacing, visual hierarchy
+- **Spatial relationships** — state machines, flowcharts, entity relationships rendered as diagrams
+
+**Use the terminal** when the content is text or tabular:
+
+- **Requirements and scope questions** — "what does X mean?", "which features are in scope?"
+- **Conceptual A/B/C choices** — picking between approaches described in words
+- **Tradeoff lists** — pros/cons, comparison tables
+- **Technical decisions** — API design, data modeling, architectural approach selection
+- **Clarifying questions** — anything where the answer is words, not a visual preference
+
+A question *about* a UI topic is not automatically a visual question. "What kind of wizard do you want?" is conceptual — use the terminal. "Which of these wizard layouts feels right?" is visual — use the browser.
+
+## How It Works
+
+The server watches a directory for HTML files and serves the newest one to the browser. You write HTML content to `screen_dir`, the user sees it in their browser and can click to select options. Selections are recorded to `state_dir/events` that you read on your next turn.
+
+**Content fragments vs full documents:** If your HTML file starts with `<!DOCTYPE` or `<html`, the server serves it as-is (just injects the helper script). Otherwise, the server automatically wraps your content in the frame template — adding the header, CSS theme, selection indicator, and all interactive infrastructure. **Write content fragments by default.** Only write full documents when you need complete control over the page.
+
+## Starting a Session
+
+```bash
+# Start server with persistence (mockups saved to project)
+scripts/start-server.sh --project-dir /path/to/project
+
+# Returns: {"type":"server-started","port":52341,"url":"http://localhost:52341",
+#           "screen_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/content",
+#           "state_dir":"/path/to/project/.superpowers/brainstorm/12345-1706000000/state"}
+```
+
+Save `screen_dir` and `state_dir` from the response. Tell user to open the URL.
+
+**Finding connection info:** The server writes its startup JSON to `$STATE_DIR/server-info`. If you launched the server in the background and didn't capture stdout, read that file to get the URL and port. When using `--project-dir`, check `<project>/.superpowers/brainstorm/` for the session directory.
+
+**Note:** Pass the project root as `--project-dir` so mockups persist in `.superpowers/brainstorm/` and survive server restarts. Without it, files go to `/tmp` and get cleaned up. Remind the user to add `.superpowers/` to `.gitignore` if it's not already there.
+
+**Launching the server by platform:**
+
+**Claude Code (macOS / Linux):**
+```bash
+# Default mode works — the script backgrounds the server itself
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Claude Code (Windows):**
+```bash
+# Windows auto-detects and uses foreground mode, which blocks the tool call.
+# Use run_in_background: true on the Bash tool call so the server survives
+# across conversation turns.
+scripts/start-server.sh --project-dir /path/to/project
+```
+When calling this via the Bash tool, set `run_in_background: true`. Then read `$STATE_DIR/server-info` on the next turn to get the URL and port.
+
+**Codex:**
+```bash
+# Codex reaps background processes. The script auto-detects CODEX_CI and
+# switches to foreground mode. Run it normally — no extra flags needed.
+scripts/start-server.sh --project-dir /path/to/project
+```
+
+**Gemini CLI:**
+```bash
+# Use --foreground and set is_background: true on your shell tool call
+# so the process survives across turns
+scripts/start-server.sh --project-dir /path/to/project --foreground
+```
+
+**Other environments:** The server must keep running in the background across conversation turns. If your environment reaps detached processes, use `--foreground` and launch the command with your platform's background execution mechanism.
+
+If the URL is unreachable from your browser (common in remote/containerized setups), bind a non-loopback host:
+
+```bash
+scripts/start-server.sh \
+  --project-dir /path/to/project \
+  --host 0.0.0.0 \
+  --url-host localhost
+```
+
+Use `--url-host` to control what hostname is printed in the returned URL JSON.
+
+## The Loop
+
+1. **Check server is alive**, then **write HTML** to a new file in `screen_dir`:
+   - Before each write, check that `$STATE_DIR/server-info` exists. If it doesn't (or `$STATE_DIR/server-stopped` exists), the server has shut down — restart it with `start-server.sh` before continuing. The server auto-exits after 30 minutes of inactivity.
+   - Use semantic filenames: `platform.html`, `visual-style.html`, `layout.html`
+   - **Never reuse filenames** — each screen gets a fresh file
+   - Use Write tool — **never use cat/heredoc** (dumps noise into terminal)
+   - Server automatically serves the newest file
+
+2. **Tell user what to expect and end your turn:**
+   - Remind them of the URL (every step, not just first)
+   - Give a brief text summary of what's on screen (e.g., "Showing 3 layout options for the homepage")
+   - Ask them to respond in the terminal: "Take a look and let me know what you think. Click to select an option if you'd like."
+
+3. **On your next turn** — after the user responds in the terminal:
+   - Read `$STATE_DIR/events` if it exists — this contains the user's browser interactions (clicks, selections) as JSON lines
+   - Merge with the user's terminal text to get the full picture
+   - The terminal message is the primary feedback; `state_dir/events` provides structured interaction data
+
+4. **Iterate or advance** — if feedback changes current screen, write a new file (e.g., `layout-v2.html`). Only move to the next question when the current step is validated.
+
+5. **Unload when returning to terminal** — when the next step doesn't need the browser (e.g., a clarifying question, a tradeoff discussion), push a waiting screen to clear the stale content:
+
+   ```html
+   <!-- filename: waiting.html (or waiting-2.html, etc.) -->
+   <div style="display:flex;align-items:center;justify-content:center;min-height:60vh">
+     <p class="subtitle">Continuing in terminal...</p>
+   </div>
+   ```
+
+   This prevents the user from staring at a resolved choice while the conversation has moved on. When the next visual question comes up, push a new content file as usual.
+
+6. Repeat until done.
+
+## Writing Content Fragments
+
+Write just the content that goes inside the page. The server wraps it in the frame template automatically (header, theme CSS, selection indicator, and all interactive infrastructure).
+
+**Minimal example:**
+
+```html
+<h2>Which layout works better?</h2>
+<p class="subtitle">Consider readability and visual hierarchy</p>
+
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Single Column</h3>
+      <p>Clean, focused reading experience</p>
+    </div>
+  </div>
+  <div class="option" data-choice="b" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>Two Column</h3>
+      <p>Sidebar navigation with main content</p>
+    </div>
+  </div>
+</div>
+```
+
+That's it. No `<html>`, no CSS, no `<script>` tags needed. The server provides all of that.
+
+## CSS Classes Available
+
+The frame template provides these CSS classes for your content:
+
+### Options (A/B/C choices)
+
+```html
+<div class="options">
+  <div class="option" data-choice="a" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>Title</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+**Multi-select:** Add `data-multiselect` to the container to let users select multiple options. Each click toggles the item. The indicator bar shows the count.
+
+```html
+<div class="options" data-multiselect>
+  <!-- same option markup — users can select/deselect multiple -->
+</div>
+```
+
+### Cards (visual designs)
+
+```html
+<div class="cards">
+  <div class="card" data-choice="design1" onclick="toggleSelect(this)">
+    <div class="card-image"><!-- mockup content --></div>
+    <div class="card-body">
+      <h3>Name</h3>
+      <p>Description</p>
+    </div>
+  </div>
+</div>
+```
+
+### Mockup container
+
+```html
+<div class="mockup">
+  <div class="mockup-header">Preview: Dashboard Layout</div>
+  <div class="mockup-body"><!-- your mockup HTML --></div>
+</div>
+```
+
+### Split view (side-by-side)
+
+```html
+<div class="split">
+  <div class="mockup"><!-- left --></div>
+  <div class="mockup"><!-- right --></div>
+</div>
+```
+
+### Pros/Cons
+
+```html
+<div class="pros-cons">
+  <div class="pros"><h4>Pros</h4><ul><li>Benefit</li></ul></div>
+  <div class="cons"><h4>Cons</h4><ul><li>Drawback</li></ul></div>
+</div>
+```
+
+### Mock elements (wireframe building blocks)
+
+```html
+<div class="mock-nav">Logo | Home | About | Contact</div>
+<div style="display: flex;">
+  <div class="mock-sidebar">Navigation</div>
+  <div class="mock-content">Main content area</div>
+</div>
+<button class="mock-button">Action Button</button>
+<input class="mock-input" placeholder="Input field">
+<div class="placeholder">Placeholder area</div>
+```
+
+### Typography and sections
+
+- `h2` — page title
+- `h3` — section heading
+- `.subtitle` — secondary text below title
+- `.section` — content block with bottom margin
+- `.label` — small uppercase label text
+
+## Browser Events Format
+
+When the user clicks options in the browser, their interactions are recorded to `$STATE_DIR/events` (one JSON object per line). The file is cleared automatically when you push a new screen.
+
+```jsonl
+{"type":"click","choice":"a","text":"Option A - Simple Layout","timestamp":1706000101}
+{"type":"click","choice":"c","text":"Option C - Complex Grid","timestamp":1706000108}
+{"type":"click","choice":"b","text":"Option B - Hybrid","timestamp":1706000115}
+```
+
+The full event stream shows the user's exploration path — they may click multiple options before settling. The last `choice` event is typically the final selection, but the pattern of clicks can reveal hesitation or preferences worth asking about.
+
+If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser — use only their terminal text.
+
+## Design Tips
+
+- **Scale fidelity to the question** — wireframes for layout, polish for polish questions
+- **Explain the question on each page** — "Which layout feels more professional?" not just "Pick one"
+- **Iterate before advancing** — if feedback changes current screen, write a new version
+- **2-4 options max** per screen
+- **Use real content when it matters** — for a photography portfolio, use actual images (Unsplash). Placeholder content obscures design issues.
+- **Keep mockups simple** — focus on layout and structure, not pixel-perfect design
+
+## File Naming
+
+- Use semantic names: `platform.html`, `visual-style.html`, `layout.html`
+- Never reuse filenames — each screen must be a new file
+- For iterations: append version suffix like `layout-v2.html`, `layout-v3.html`
+- Server serves newest file by modification time
+
+## Cleaning Up
+
+```bash
+scripts/stop-server.sh $SESSION_DIR
+```
+
+If the session used `--project-dir`, mockup files persist in `.superpowers/brainstorm/` for later reference. Only `/tmp` sessions get deleted on stop.
+
+## Reference
+
+- Frame template (CSS reference): `scripts/frame-template.html`
+- Helper script (client-side): `scripts/helper.js`

--- a/plugins/workbench/skills/using-workbench/SKILL.md
+++ b/plugins/workbench/skills/using-workbench/SKILL.md
@@ -1,30 +1,122 @@
 ---
 name: using-workbench
-description: Use when starting any conversation alongside using-superpowers. Announces workbench's currently-shipped skills, defers meta-rules to using-superpowers, and resolves slug collisions in workbench's favor.
+description: Use when starting any conversation, establishes how to find and use workbench skills, requiring Skill tool invocation before any response including clarifying questions
 ---
 
-# Using Workbench
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
 
-This skill is a thin companion to `using-superpowers`. Workbench layers on top of the upstream Superpowers plugin and forks individual skills as Pascal commits to owning them.
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
 
-## Relationship to using-superpowers
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
 
-The meta-rules for working with skills (when to invoke them, how to treat triggers, the "even 1% relevance" rule, the rule against rationalizing past skill use, the SUBAGENT-STOP block, the platform tool-name mapping) are owned by `using-superpowers`. This skill does NOT restate them.
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
 
-If `superpowers` is not installed, see `references/using-superpowers-upstream.md` in this skill directory for the meta-rules in their original form, frozen at upstream version 5.0.7. Either install upstream, or promote that content into this skill body.
+## Instruction Priority
 
-## Workbench skills
+Workbench skills override default system prompt behavior, but **user instructions always take precedence**:
 
-Today, Workbench ships:
+1. **User's explicit instructions** (CLAUDE.md, AGENTS.md, direct requests) — highest priority
+2. **Workbench skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
 
-- `brainstorming`: design dialogue that turns an idea into a spec, with a visual-companion mode
+If CLAUDE.md or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
 
-As more skills are forked into Workbench, add them to this list and promote relevant chunks from `references/using-superpowers-upstream.md` into this skill body.
+## How to Access Skills
 
-## Slug collision rule
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
 
-When a skill name exists in both Workbench and Superpowers, prefer the Workbench version. Today the only collision is `brainstorming`. The host agent should resolve the bare slug `brainstorming` to `workbench:brainstorming`.
+**In Codex:** Skills are auto-discovered from installed plugins and activate via Codex's plugin skill mechanism.
 
-## Reference file
+## Platform Adaptation
 
-`references/using-superpowers-upstream.md` is a verbatim snapshot of the upstream `using-superpowers/SKILL.md` at version 5.0.7. It exists so that, as more skills are ported, their corresponding chunks of meta-guidance can be lifted out of the snapshot and into this skill body.
+Skills use Claude Code tool names by default. Codex users: see `references/codex-tools.md` for tool equivalents.
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming) - these determine HOW to approach the task
+2. **Implementation skills second** - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+
+## Skill Types
+
+**Rigid**: Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+---
+
+## Coexistence with using-superpowers
+
+Workbench coexists with the upstream `superpowers` plugin. If both are installed, both meta-skills (`using-workbench` and `using-superpowers`) may fire at session start. Their content overlaps but workbench's version is authoritative for workbench skills.
+
+When a slug exists in both workbench and superpowers (today: `brainstorming`), prefer the workbench version. The host agent should resolve the bare slug `brainstorming` to `workbench:brainstorming`.
+
+For attribution and a frozen snapshot of upstream `using-superpowers/SKILL.md` at v5.0.7, see `references/using-superpowers-upstream.md`. Workbench-specific divergences from that snapshot are documented in this file's git history; the snapshot itself is intentionally not edited.

--- a/plugins/workbench/skills/using-workbench/SKILL.md
+++ b/plugins/workbench/skills/using-workbench/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: using-workbench
+description: Use when starting any conversation alongside using-superpowers. Announces workbench's currently-shipped skills, defers meta-rules to using-superpowers, and resolves slug collisions in workbench's favor.
+---
+
+# Using Workbench
+
+This skill is a thin companion to `using-superpowers`. Workbench layers on top of the upstream Superpowers plugin and forks individual skills as Pascal commits to owning them.
+
+## Relationship to using-superpowers
+
+The meta-rules for working with skills (when to invoke them, how to treat triggers, the "even 1% relevance" rule, the rule against rationalizing past skill use, the SUBAGENT-STOP block, the platform tool-name mapping) are owned by `using-superpowers`. This skill does NOT restate them.
+
+If `superpowers` is not installed, see `references/using-superpowers-upstream.md` in this skill directory for the meta-rules in their original form, frozen at upstream version 5.0.7. Either install upstream, or promote that content into this skill body.
+
+## Workbench skills
+
+Today, Workbench ships:
+
+- `brainstorming`: design dialogue that turns an idea into a spec, with a visual-companion mode
+
+As more skills are forked into Workbench, add them to this list and promote relevant chunks from `references/using-superpowers-upstream.md` into this skill body.
+
+## Slug collision rule
+
+When a skill name exists in both Workbench and Superpowers, prefer the Workbench version. Today the only collision is `brainstorming`. The host agent should resolve the bare slug `brainstorming` to `workbench:brainstorming`.
+
+## Reference file
+
+`references/using-superpowers-upstream.md` is a verbatim snapshot of the upstream `using-superpowers/SKILL.md` at version 5.0.7. It exists so that, as more skills are ported, their corresponding chunks of meta-guidance can be lifted out of the snapshot and into this skill body.

--- a/plugins/workbench/skills/using-workbench/references/codex-tools.md
+++ b/plugins/workbench/skills/using-workbench/references/codex-tools.md
@@ -1,0 +1,100 @@
+# Codex Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use your platform equivalent:
+
+| Skill references | Codex equivalent |
+|-----------------|------------------|
+| `Task` tool (dispatch subagent) | `spawn_agent` (see [Named agent dispatch](#named-agent-dispatch)) |
+| Multiple `Task` calls (parallel) | Multiple `spawn_agent` calls |
+| Task returns result | `wait` |
+| Task completes automatically | `close_agent` to free slot |
+| `TodoWrite` (task tracking) | `update_plan` |
+| `Skill` tool (invoke a skill) | Skills load natively — just follow the instructions |
+| `Read`, `Write`, `Edit` (files) | Use your native file tools |
+| `Bash` (run commands) | Use your native shell tools |
+
+## Subagent dispatch requires multi-agent support
+
+Add to your Codex config (`~/.codex/config.toml`):
+
+```toml
+[features]
+multi_agent = true
+```
+
+This enables `spawn_agent`, `wait`, and `close_agent` for skills like `dispatching-parallel-agents` and `subagent-driven-development`.
+
+## Named agent dispatch
+
+Claude Code skills reference named agent types like `superpowers:code-reviewer`.
+Codex does not have a named agent registry — `spawn_agent` creates generic agents
+from built-in roles (`default`, `explorer`, `worker`).
+
+When a skill says to dispatch a named agent type:
+
+1. Find the agent's prompt file (e.g., `agents/code-reviewer.md` or the skill's
+   local prompt template like `code-quality-reviewer-prompt.md`)
+2. Read the prompt content
+3. Fill any template placeholders (`{BASE_SHA}`, `{WHAT_WAS_IMPLEMENTED}`, etc.)
+4. Spawn a `worker` agent with the filled content as the `message`
+
+| Skill instruction | Codex equivalent |
+|-------------------|------------------|
+| `Task tool (superpowers:code-reviewer)` | `spawn_agent(agent_type="worker", message=...)` with `code-reviewer.md` content |
+| `Task tool (general-purpose)` with inline prompt | `spawn_agent(message=...)` with the same prompt |
+
+### Message framing
+
+The `message` parameter is user-level input, not a system prompt. Structure it
+for maximum instruction adherence:
+
+```
+Your task is to perform the following. Follow the instructions below exactly.
+
+<agent-instructions>
+[filled prompt content from the agent's .md file]
+</agent-instructions>
+
+Execute this now. Output ONLY the structured response following the format
+specified in the instructions above.
+```
+
+- Use task-delegation framing ("Your task is...") rather than persona framing ("You are...")
+- Wrap instructions in XML tags — the model treats tagged blocks as authoritative
+- End with an explicit execution directive to prevent summarization of the instructions
+
+### When this workaround can be removed
+
+This approach compensates for Codex's plugin system not yet supporting an `agents`
+field in `plugin.json`. When `RawPluginManifest` gains an `agents` field, the
+plugin can symlink to `agents/` (mirroring the existing `skills/` symlink) and
+skills can dispatch named agent types directly.
+
+## Environment Detection
+
+Skills that create worktrees or finish branches should detect their
+environment with read-only git commands before proceeding:
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+BRANCH=$(git branch --show-current)
+```
+
+- `GIT_DIR != GIT_COMMON` → already in a linked worktree (skip creation)
+- `BRANCH` empty → detached HEAD (cannot branch/push/PR from sandbox)
+
+See `using-git-worktrees` Step 0 and `finishing-a-development-branch`
+Step 1 for how each skill uses these signals.
+
+## Codex App Finishing
+
+When the sandbox blocks branch/push operations (detached HEAD in an
+externally managed worktree), the agent commits all work and informs
+the user to use the App's native controls:
+
+- **"Create branch"** — names the branch, then commit/push/PR via App UI
+- **"Hand off to local"** — transfers work to the user's local checkout
+
+The agent can still run tests, stage files, and output suggested branch
+names, commit messages, and PR descriptions for the user to copy.

--- a/plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md
+++ b/plugins/workbench/skills/using-workbench/references/using-superpowers-upstream.md
@@ -1,0 +1,131 @@
+<!--
+SNAPSHOT NOTE
+=============
+Source: superpowers plugin v5.0.7
+Origin path: skills/using-superpowers/SKILL.md
+Snapshot date: 2026-05-04
+Purpose: Frozen reference for the using-workbench skill. As Workbench
+forks more skills from upstream, lift the corresponding chunks of
+meta-guidance out of this file and into using-workbench/SKILL.md.
+This file is intentionally NOT a skill (no frontmatter recognized as
+skill metadata; subdirectory `references/` is by convention not loaded
+as a skill).
+-->
+
+---
+name: using-superpowers
+description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Superpowers skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+2. **Superpowers skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
+
+**In Copilot CLI:** Use the `skill` tool. Skills are auto-discovered from installed plugins. The `skill` tool works the same as Claude Code's `Skill` tool.
+
+**In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Platform Adaptation
+
+Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/tests/unit/test-codex-plugin-structure.sh
+++ b/tests/unit/test-codex-plugin-structure.sh
@@ -18,9 +18,9 @@ marketplace_name="$(jq -r '.name' "$MARKETPLACE")"
 [ "$marketplace_name" = "pgoell-claude-tools" ] || fail "Unexpected marketplace name: $marketplace_name"
 
 plugin_count="$(jq '.plugins | length' "$MARKETPLACE")"
-[ "$plugin_count" -eq 6 ] || fail "Expected 6 Codex marketplace plugins, got $plugin_count"
+[ "$plugin_count" -eq 7 ] || fail "Expected 7 Codex marketplace plugins, got $plugin_count"
 
-for plugin in atlassian google-workspace research writing runtime-bridge agents-md-management; do
+for plugin in atlassian google-workspace research writing runtime-bridge agents-md-management workbench; do
     plugin_dir="$REPO_ROOT/plugins/$plugin"
     manifest="$plugin_dir/.codex-plugin/plugin.json"
 


### PR DESCRIPTION
## Summary

Adds a new `workbench` plugin to the marketplace, holding personal forks of skills used regularly. Initial port from upstream `superpowers` v5.0.7:

- `brainstorming` skill (full port with surgical rebrand: spec output path, terminal handoff target, visual-companion paths, page header)
- `using-workbench` meta-skill (freshly authored as a trimmed companion to upstream `using-superpowers`; defers core meta-rules upstream and announces workbench's slug-collision rule)
- Dual-runtime SessionStart hook: `hooks/hooks.json` for Claude Code (uses `${CLAUDE_PLUGIN_ROOT}`), `hooks.json` at plugin root for Codex (plugin-root-relative, mirroring the figma plugin precedent)
- LICENSE (MIT, copied from upstream) + NOTICE (lists derived files) + plugin README with Credits section
- Marketplace registrations in both `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`
- Repo `README.md`, `AGENTS.md`, and `tests/unit/test-codex-plugin-structure.sh` updated to include workbench

Mode is fork-as-you-touch: workbench coexists with the upstream `superpowers` plugin. The brainstorming skill's terminal handoff continues to invoke `superpowers:writing-plans` cross-plugin until that skill is also ported in a future wave. The `using-workbench` skill ships a frozen snapshot of upstream `using-superpowers/SKILL.md` as a reference sidecar at `references/using-superpowers-upstream.md`, so chunks can be promoted into the workbench meta-skill body as more skills are ported.

Spec and plan committed alongside the implementation:
- Spec: `docs/workbench/specs/2026-05-04-workbench-brainstorming-port-design.md`
- Plan: `docs/workbench/plans/2026-05-04-workbench-brainstorming-port.md`

Deferred (IOU): forks of `writing-plans` / `executing-plans` / other superpowers skills; tests for workbench skills; verifying that Codex actually fires plugin-level SessionStart hooks at runtime (the schema is recognized but the figma precedent labels its hook "draft for future plugin hook runtimes").

## Test plan

- [x] All 7 JSON files in the diff parse (workbench manifests, both hook configs, both marketplace files)
- [x] `tests/unit/test-codex-plugin-structure.sh` passes (now expects 7 plugins)
- [x] `bash -n` clean on `hooks/session-start`, `start-server.sh`, `stop-server.sh`
- [x] Audit residual `superpowers` references in `plugins/workbench/`: only acceptable hits remain (`superpowers:writing-plans` cross-plugin handoff, `obra/superpowers` upstream URL in NOTICE, `using-superpowers` in body of using-workbench/SKILL.md discussing the upstream relationship, full upstream snapshot file under `references/`)
- [x] Plugin file inventory matches the spec's Plugin shape section exactly (19 files)
- [ ] Smoke-trigger the workbench:brainstorming skill in a real Claude Code session and verify it reaches design output without erroring on the cross-plugin `superpowers:writing-plans` handoff
- [ ] Smoke-trigger via Codex once installed; observe whether the SessionStart hook actually fires (open question per spec; non-blocking either way)