### PR TITLE
feat(workbench): add autopilot project-profile convention (PR 1/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Audit and maintain `AGENTS.md` / `CLAUDE.md` files (and variants like `AGENTS.lo
 
 ### workbench
 
-Personal fork-as-you-touch skill collection. Today: brainstorming (a design dialogue that turns ideas into specs, with a browser-based visual companion) and a trimmed meta-skill that layers on top of upstream `superpowers:using-superpowers`. More skills will be added as Pascal commits to owning them.
+Personal fork-as-you-touch skill collection. Today: brainstorming (a design dialogue that turns ideas into specs, with a browser-based visual companion), a trimmed meta-skill that layers on top of upstream `superpowers:using-superpowers`, and the autopilot project-profile convention (`plugins/workbench/skills/autopilot/references/profile-schema.md`); the autopilot skill itself ships in a follow-up PR. More skills will be added as Pascal commits to owning them.
 
 **Skills:**
 - `/pgoell-claude-tools:brainstorming`: Design dialogue from idea to spec, with a visual-companion mode

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -7,6 +7,12 @@ Personal fork-as-you-touch skill collection.
 - `brainstorming`: Design dialogue that turns an idea into a spec, with a visual-companion mode for browser-based mockups. Forked from upstream Superpowers and adapted with Workbench-specific paths.
 - `using-workbench`: Trimmed meta-skill that announces what Workbench ships and resolves slug collisions in Workbench's favor. Defers core meta-rules to the upstream `using-superpowers` skill.
 
+## Project profiles
+
+Workbench owns reusable agent workflows. Projects own their local policy through small profile files at `.workbench/<skill>.md`. Today this convention is documented for the upcoming `autopilot` skill (PR 2 in the autopilot port); see [`skills/autopilot/references/profile-schema.md`](skills/autopilot/references/profile-schema.md) for the schema and [`skills/autopilot/references/example-project-profile.md`](skills/autopilot/references/example-project-profile.md) for examples.
+
+The split: workbench ships the kernel (steps, audit, invariants); the project profile carries autopilot-specific bits (PR behavior, hooks, audit-table overrides). Project information that already lives in `CLAUDE.md` or `AGENTS.md` is sourced from session context, not duplicated in the profile.
+
 ## Coexistence
 
 Workbench is designed to run alongside the upstream `superpowers` plugin. When a slug exists in both plugins (today: `brainstorming`), prefer the Workbench version.

--- a/plugins/workbench/skills/autopilot/references/example-project-profile.md
+++ b/plugins/workbench/skills/autopilot/references/example-project-profile.md
@@ -1,0 +1,82 @@
+# Example Workbench Autopilot Profiles
+
+Two examples in one file. Copy whichever shape fits and adapt.
+
+## Example 1: Recommended minimum
+
+The smallest profile that does anything explicit. Use this as the starting point for a new project.
+
+```md
+# Workbench Autopilot Profile
+
+## PR behavior
+Mode: stop_at_green
+```
+
+That is the entire file. Defaults cover everything else: branch detected from `git symbolic-ref`, task runner detected from `mise.toml` / `Makefile` / `package.json`, doc paths inferred from existence, no overrides on the universal required-skills table, no hooks. Autopilot stops at green CI; you merge manually.
+
+## Example 2: Kitchen sink
+
+Every optional heading populated. This is what a fully-tuned project profile looks like (fictional project `widgetshop`).
+
+```md
+# Workbench Autopilot Profile
+
+## Project name
+widgetshop
+
+## Branching
+Default branch: master
+Branch prefixes: feat, fix, docs, chore, refactor, test, perf, style, ci, build, revert
+
+## Commands
+Task runner: mise run
+Lint: lint
+Test: test
+Format: fmt
+
+## Documentation paths
+Specs: docs/superpowers/specs
+Plans: docs/superpowers/plans
+Open things: docs/superpowers/OPEN_THINGS.md
+ADRs: docs/adr
+
+## PR behavior
+Mode: automerge
+Base branch: master
+Squash: yes
+
+Hooks:
+- post_pr: python3 .claude/commands/post_brainstorm_comments.py {{pr}}
+- post_ci_green: ./scripts/notify-slack.sh "{{pr}} merged"
+
+## Required skills
+| Step | Skill | Action |
+|---|---|---|
+| 4 | workbench:writing-plans | replaces superpowers:writing-plans |
+| 6 | widgetshop:regenerate-changelog | additional |
+
+## Project-specific rules
+
+Before any step that runs Python tests touching `widget_solver` (the maturin-built PyO3 binding), if an earlier task in the same autopilot run modified `solver/solver-core/` or `solver/solver-py/`, run `mise run solver:rebuild` first. A stale binding will surface phantom wire-format errors that look like real bugs.
+
+After backend Pydantic schema changes, regenerate frontend API types with `mise run fe:types` before any task that touches `frontend/src/api/`.
+
+Use `mise exec --` for `git push` so the pinned lefthook runs.
+```
+
+## When to omit a heading
+
+If the same information already lives in your project's `CLAUDE.md` or `AGENTS.md`, omit the heading from the profile. The autopilot skill reads project information in this order: profile → session context (`CLAUDE.md`, `AGENTS.md`) → git/filesystem detection → ask the user.
+
+For example, if `CLAUDE.md` already says "default branch is master" and "use `mise run` for tasks," your profile can drop both `## Branching` and `## Commands`. The kitchen-sink example duplicates them only to show the full vocabulary.
+
+## What stays autopilot-coupled
+
+Some things genuinely belong in the profile rather than `CLAUDE.md`:
+
+- `## PR behavior` and `Hooks`: workflow policy, not project info.
+- `## Required skills`: overrides on autopilot's audit table, only meaningful in autopilot's context.
+- `## Project-specific rules` that govern the autopilot run itself (like the solver-rebuild ordering above): autopilot-coupled, even if the underlying fact (the binding) is also a `CLAUDE.md` topic.
+
+When in doubt: if the rule only matters during an autopilot run, put it in the profile. If it's a general project fact, put it in `CLAUDE.md` or `AGENTS.md`.

--- a/plugins/workbench/skills/autopilot/references/profile-schema.md
+++ b/plugins/workbench/skills/autopilot/references/profile-schema.md
@@ -1,0 +1,161 @@
+# Workbench Autopilot Profile Schema
+
+This document defines the convention for `.workbench/autopilot.md` files in projects that use the `workbench:autopilot` skill. The autopilot skill itself ships in PR 2; this doc describes the convention it will consume.
+
+## What goes in the profile
+
+Workbench owns the reusable autopilot loop (the ten steps, the audit, the invariants). Projects own their local reality through this profile. The profile is intentionally small: most project information that autopilot needs (default branch, task runner, paths) is already documented in `CLAUDE.md` or `AGENTS.md` and reaches the agent through regular session context. The profile carries the autopilot-specific bits that don't naturally belong in a project's root memory file: PR behavior, hooks, audit-table overrides.
+
+## Discovery (v1)
+
+The autopilot skill looks for **one** file: `.workbench/autopilot.md` in the repo root. Missing file is a hard stop; autopilot refuses to run and points the user at the example profile.
+
+The broader fallback chain enumerated in issue 23 (`AGENTS.md`, `CLAUDE.md`, `README.md`, `.workbench/autopilot.yaml|yml`) is **deferred**. None of those branches are walked in v1. They are documented here as future enumerations:
+
+- `.workbench/autopilot.yaml` and `.workbench/autopilot.yml`: enable when there is a concrete parser-consuming use case (validation script, profile linter).
+- `AGENTS.md` / `CLAUDE.md` / `README.md` fallback: enable when there is demand for "autopilot in a repo without a `.workbench/` directory."
+
+Until then, projects that want autopilot create `.workbench/autopilot.md` explicitly.
+
+## Markdown-first stance (no parser)
+
+Headings are conventions, not contracts. Both Claude Code and Codex consume the profile as prompt context; there is no parser anywhere. The autopilot skill reads the recommended shape and extracts what it needs section by section.
+
+YAML support is deferred until a concrete parser-consuming use case exists.
+
+## Profile shape
+
+### Recommended minimum
+
+```md
+# Workbench Autopilot Profile
+
+## PR behavior
+Mode: stop_at_green
+```
+
+This is the suggested starting point. Adoption is explicit (you opted in by creating the file); the body is overrides on defaults.
+
+### Truly minimal (also valid)
+
+An empty `.workbench/autopilot.md` is valid. Presence of the file is the opt-in signal.
+
+### Full heading vocabulary (all optional)
+
+```md
+# Workbench Autopilot Profile
+
+## Project name
+<short slug; defaults to repo dir basename>
+
+## Branching
+Default branch: <name>
+Branch prefixes: <feat, fix, docs, chore, refactor, test, perf, style, ci, build, revert>
+
+## Commands
+Task runner: <mise run | make | pnpm run | npm run>
+Lint: <command suffix>
+Test: <command suffix>
+Format: <command suffix>
+
+## Documentation paths
+Specs: <path>
+Plans: <path>
+Open things: <file>
+ADRs: <dir>
+
+## PR behavior
+Mode: <stop_at_green | automerge | request_review>
+Base branch: <name; defaults to default branch>
+Squash: <yes | no; defaults to yes>
+
+Hooks:
+- post_spec: <command>
+- post_plan: <command>
+- post_implementation: <command>
+- post_pr: <command>
+- post_ci_green: <command>
+
+## Required skills
+| Step | Skill | Action |
+|---|---|---|
+| <n> | <skill-id> | replaces <existing-skill-id> |
+| <n> | <skill-id> | additional |
+
+## Project-specific rules
+<free prose; rules autopilot must respect during the run>
+```
+
+## Defaults when a section is absent
+
+| Section | Default |
+|---|---|
+| `## PR behavior` | `Mode: stop_at_green`, `Base branch:` = default branch, `Squash: yes`, no hooks |
+| `## Required skills` | universal table only, no overrides, no additions |
+| `## Project name` | repo dir basename |
+| `## Branching` | default branch detected via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`; standard Conventional Commits prefixes |
+| `## Commands` | task runner detected from `mise.toml` / `Makefile` / `package.json`; lint and test commands inferred from runner conventions |
+| `## Documentation paths` | `docs/superpowers/specs`, `docs/superpowers/plans`, `docs/superpowers/OPEN_THINGS.md`, `docs/adr`; each used only if it exists |
+| `## Project-specific rules` | none beyond what `CLAUDE.md` or `AGENTS.md` provides |
+
+## Bootstrap precedence
+
+When the autopilot skill needs project information, it resolves each field in this order:
+
+1. Profile section in `.workbench/autopilot.md`.
+2. Session context (`CLAUDE.md`, `AGENTS.md`, both already loaded into the agent).
+3. Git or filesystem detection (`git symbolic-ref`, presence of `mise.toml`, etc.).
+4. Ask the user. Never guess.
+
+A field that no source provides and the active step needs (for example, a test command in a project with neither `mise.toml` nor `Makefile` nor `package.json`) stops the workflow with a question, not a guess.
+
+## PR behavior modes
+
+| Mode | Behavior |
+|---|---|
+| `stop_at_green` | Default. Autopilot stops once CI is green and reports the PR URL. The user merges manually. |
+| `automerge` | Autopilot runs `gh pr merge <pr> --auto --squash` (or `--merge` if `Squash: no`), polls until the PR state is `MERGED`, refreshes local default branch, deletes the feature branch, reports the merged commit hash. |
+| `request_review` | Autopilot runs `gh pr ready <pr>` and posts a reviewer note; merge stays manual. |
+
+## Hooks
+
+Each hook value is a shell command. The autopilot skill substitutes `{{pr}}`, `{{branch}}`, `{{spec_path}}`, `{{plan_path}}` into the command before invocation. Hook failures are reported but do not block the workflow unless the project's `## Project-specific rules` section says otherwise.
+
+| Hook | Fires when |
+|---|---|
+| `post_spec` | After the spec commit in step 3 |
+| `post_plan` | After the plan commit in step 4 |
+| `post_implementation` | After the last implementation commit in step 5 |
+| `post_pr` | After `gh pr create` succeeds in step 7 |
+| `post_ci_green` | After step 8 turns green |
+
+## Required-skills overrides
+
+The profile's `## Required skills` table supports two operations on the autopilot skill's universal required-skills table (defined in `references/required-skills.md` once PR 2 lands):
+
+- **Replace.** A row matching an existing step swaps which skill fulfills it. Example: `Step 4 | workbench:writing-plans | replaces superpowers:writing-plans`. The audit walks the replacement instead of the universal row.
+- **Additional.** A row marked `additional` adds a new mandatory skill at a step. Example: `Step 6 | my-project:custom-changelog | additional`. The audit walks the universal row and the additional row.
+
+Removal is not supported. The profile cannot weaken the universal discipline floor.
+
+## Audit semantics
+
+When the autopilot skill walks its pre-PR audit, it covers:
+
+1. The universal required-skills table merged with profile `## Required skills` overrides.
+2. Skill or command references in the profile's `## Project-specific rules` section.
+3. Skill discipline rules in the project's `CLAUDE.md` or `AGENTS.md` that name a skill.
+
+Anything mentioned in any of those three sources must have been invoked during the run, or the audit blocks the push.
+
+## Authoring tips
+
+- Omit a heading if the project's `CLAUDE.md` or `AGENTS.md` already documents the same information; the autopilot skill will source it from session context.
+- Use `## Project-specific rules` for autopilot-coupled rules that don't naturally belong in `CLAUDE.md`, for example "before pytest, rebuild the PyO3 binding via `mise run solver:rebuild`."
+- Keep the profile small. The kitchen-sink example exists to show all the dials, not as a target.
+
+## See also
+
+- `example-project-profile.md`: minimal and kitchen-sink examples.
+- `../SKILL.md` (lands in PR 2): the autopilot skill that consumes the profile.
+- Issue 23 in this repo's tracker: the strategic motivation for the kernel-vs-policy split.

--- a/tests/unit/test-workbench-profile-schema.sh
+++ b/tests/unit/test-workbench-profile-schema.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Test: workbench autopilot profile schema reference docs
+# Verifies PR 1 of the autopilot port: profile-schema.md and example-project-profile.md
+# exist, contain the documented heading skeleton, and READMEs link to them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCHEMA="$REPO_ROOT/plugins/workbench/skills/autopilot/references/profile-schema.md"
+EXAMPLE="$REPO_ROOT/plugins/workbench/skills/autopilot/references/example-project-profile.md"
+WORKBENCH_README="$REPO_ROOT/plugins/workbench/README.md"
+ROOT_README="$REPO_ROOT/README.md"
+
+echo "=== Test: workbench autopilot profile foundation ==="
+echo ""
+
+# Test 1: Both reference files exist and are non-empty
+echo "Test 1: Reference files exist..."
+for f in "$SCHEMA" "$EXAMPLE"; do
+    if [ -s "$f" ]; then
+        echo "  [PASS] $(basename "$f") exists"
+    else
+        echo "  [FAIL] $(basename "$f") missing or empty"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 2: profile-schema.md documents the heading skeleton
+echo "Test 2: profile-schema.md documents heading skeleton..."
+for heading in 'PR behavior' 'Required skills' 'Project name' 'Branching' 'Commands' 'Documentation paths' 'Project-specific rules'; do
+    if grep -qF "## $heading" "$SCHEMA"; then
+        echo "  [PASS] schema mentions '## $heading'"
+    else
+        echo "  [FAIL] schema missing '## $heading'"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 3: profile-schema.md documents discovery and Markdown-first stance
+echo "Test 3: profile-schema.md documents discovery rules..."
+for term in 'Discovery' 'Markdown-first' 'YAML' 'Bootstrap precedence' 'replaces' 'additional'; do
+    if grep -qiF "$term" "$SCHEMA"; then
+        echo "  [PASS] schema mentions '$term'"
+    else
+        echo "  [FAIL] schema missing '$term'"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 4: example-project-profile.md contains both examples
+echo "Test 4: example-project-profile.md contains both examples..."
+for label in 'Example 1' 'Example 2' 'Recommended minimum' 'Kitchen sink'; do
+    if grep -qiF "$label" "$EXAMPLE"; then
+        echo "  [PASS] example mentions '$label'"
+    else
+        echo "  [FAIL] example missing '$label'"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 5: example mentions stop_at_green and automerge modes
+echo "Test 5: example shows PR behavior modes..."
+for mode in 'stop_at_green' 'automerge'; do
+    if grep -qF "$mode" "$EXAMPLE"; then
+        echo "  [PASS] example mentions '$mode'"
+    else
+        echo "  [FAIL] example missing '$mode'"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 6: workbench README links to the schema
+echo "Test 6: workbench README links to profile-schema.md..."
+if grep -qF 'profile-schema.md' "$WORKBENCH_README"; then
+    echo "  [PASS] workbench README links to profile-schema.md"
+else
+    echo "  [FAIL] workbench README missing link to profile-schema.md"
+    exit 1
+fi
+if grep -qF 'example-project-profile.md' "$WORKBENCH_README"; then
+    echo "  [PASS] workbench README links to example-project-profile.md"
+else
+    echo "  [FAIL] workbench README missing link to example-project-profile.md"
+    exit 1
+fi
+echo ""
+
+# Test 7: workbench README explains kernel-vs-policy split
+echo "Test 7: workbench README explains the split..."
+if grep -qiE 'kernel|reusable|generic workflow' "$WORKBENCH_README" \
+   && grep -qiE 'profile|local policy|local reality' "$WORKBENCH_README"; then
+    echo "  [PASS] workbench README explains the split"
+else
+    echo "  [FAIL] workbench README missing kernel-vs-policy explanation"
+    exit 1
+fi
+echo ""
+
+# Test 8: root README mentions the profile schema
+echo "Test 8: root README mentions profile-schema..."
+if grep -qF 'profile-schema' "$ROOT_README"; then
+    echo "  [PASS] root README mentions profile-schema"
+else
+    echo "  [FAIL] root README missing profile-schema reference"
+    exit 1
+fi
+echo ""
+
+# Test 9: schema notes deferred fallbacks
+echo "Test 9: schema notes deferred fallback chain..."
+for deferred in 'AGENTS.md' 'CLAUDE.md' 'README.md' 'autopilot.yaml'; do
+    if grep -qF "$deferred" "$SCHEMA"; then
+        echo "  [PASS] schema mentions deferred '$deferred'"
+    else
+        echo "  [FAIL] schema missing mention of deferred '$deferred'"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 10: schema documents bootstrap precedence
+echo "Test 10: schema documents bootstrap precedence..."
+if grep -qiF 'profile' "$SCHEMA" \
+   && grep -qiE 'CLAUDE\.md.*AGENTS\.md|AGENTS\.md.*CLAUDE\.md' "$SCHEMA" \
+   && grep -qiE 'detection|symbolic-ref|filesystem' "$SCHEMA"; then
+    echo "  [PASS] schema documents precedence chain"
+else
+    echo "  [FAIL] schema missing precedence chain"
+    exit 1
+fi
+echo ""
+
+echo "=== Tests complete ==="


### PR DESCRIPTION
## Summary

Lands the workbench autopilot project-profile convention as docs only, per issue #23 PR-slicing (this is PR 1 of 2). No skill consumes the profile yet; PR 2 will add the autopilot skill that does.

- New `plugins/workbench/skills/autopilot/references/profile-schema.md` documents the convention: discovery, Markdown-first stance, heading skeleton, defaults, bootstrap precedence, deferred fallbacks, audit semantics.
- New `plugins/workbench/skills/autopilot/references/example-project-profile.md` ships two examples: a recommended-minimum profile and a kitchen-sink profile.
- `plugins/workbench/README.md` adds a `## Project profiles` section explaining the kernel-vs-policy split with links to both reference docs.
- Root `README.md` links to the profile convention.
- `tests/unit/test-workbench-profile-schema.sh` pins the docs' shape (heading skeleton, README links, deferred fallbacks documented, both examples present).

Spec: `docs/superpowers/specs/2026-05-05-workbench-autopilot-port-design.md`.

## Test plan

- [ ] `bash tests/unit/test-workbench-profile-schema.sh` passes locally
- [ ] CI passes
- [ ] Workbench README renders correctly on GitHub (links resolve)
- [ ] Root README renders correctly on GitHub