### PR TITLE
feat(workbench): add autopilot skill (PR 2/2)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -113,7 +113,7 @@
       "category": "Productivity",
       "interface": {
         "displayName": "Workbench",
-        "shortDescription": "Personal forks of skills Pascal uses regularly"
+        "shortDescription": "Personal skill forks: brainstorming, using-workbench, and autopilot (autonomous feature-flow skill)"
       }
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,8 +43,8 @@
     {
       "name": "workbench",
       "source": "./plugins/workbench",
-      "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
-      "version": "0.1.0"
+      "description": "Personal fork-as-you-touch skill collection: brainstorming, using-workbench meta-skill, and the autopilot autonomous feature-flow skill (kernel + project profile at .workbench/autopilot.md)",
+      "version": "0.2.0"
     }
   ]
 }

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workbench",
-  "version": "0.1.0",
-  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "version": "0.2.0",
+  "description": "Personal fork-as-you-touch skill collection: brainstorming, using-workbench meta-skill, and the autopilot autonomous feature-flow skill",
   "author": {
     "name": "Pascal Göllner"
   },

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workbench",
-  "version": "0.1.0",
-  "description": "Personal fork-as-you-touch skill collection (brainstorming + meta-skill, more to come)",
+  "version": "0.2.0",
+  "description": "Personal fork-as-you-touch skill collection: brainstorming, using-workbench meta-skill, and the autopilot autonomous feature-flow skill",
   "author": {
     "name": "Pascal Göllner"
   },
@@ -11,13 +11,14 @@
     "brainstorming",
     "design",
     "specs",
-    "workflow"
+    "workflow",
+    "autopilot"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Workbench",
     "shortDescription": "Personal forks of skills Pascal uses regularly",
-    "longDescription": "Personal fork-as-you-touch skill collection. Today: brainstorming (with visual companion) and a meta-skill that layers on top of using-superpowers. More skills will be added as Pascal commits to owning them.",
+    "longDescription": "Personal fork-as-you-touch skill collection. Today: brainstorming (with visual companion), a using-workbench meta-skill that layers on top of using-superpowers, and the autopilot skill which runs the full autonomous brainstorm-spec-plan-implement-PR-green-CI flow against a project profile at .workbench/autopilot.md. More skills will be added as Pascal commits to owning them.",
     "developerName": "Pascal Göllner",
     "category": "Productivity",
     "capabilities": [
@@ -27,7 +28,8 @@
     "defaultPrompt": [
       "Help me brainstorm a new feature",
       "Turn my idea into a spec",
-      "Run the design dialogue for this project"
+      "Run the design dialogue for this project",
+      "Use autopilot to autonomously ship this feature"
     ],
     "screenshots": []
   }

--- a/plugins/workbench/skills/autopilot/SKILL.md
+++ b/plugins/workbench/skills/autopilot/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: autopilot
+description: Use when the user wants to autonomously ship a feature end-to-end (brainstorm, spec, plan, implement, PR, green CI) using a configured project profile at .workbench/autopilot.md
+---
+
+# Autopilot: autonomous feature flow
+
+You are running the workbench autopilot workflow. The user has opted into autonomous mode: make your own recommendations, do not pause for confirmation on routine choices, only stop if the topic is too large for a single spec (then decompose and ask which sub-topic to tackle first).
+
+## Bootstrap
+
+**First action:** find `.workbench/autopilot.md` in the current repo root.
+
+If the file is missing: stop. Tell the user that autopilot requires a project profile at `.workbench/autopilot.md`, and surface the example file at `references/example-project-profile.md` as a starting point. The full profile format is documented in `references/profile-schema.md`. Do not attempt to detect a missing profile.
+
+If the file exists:
+
+1. Read `## PR behavior` and apply: `Mode` (default `stop_at_green`), `Base branch` (default = repo default branch), `Squash` (default `yes`), `Hooks` (each optional).
+2. Read `## Required skills` if present; merge `replaces` and `additional` rows into the universal table from `references/required-skills.md`.
+3. For other project information (default branch, task runner, doc paths, project rules), resolve in this order, per field:
+   - Profile heading.
+   - Session context (`CLAUDE.md`, `AGENTS.md`, both already loaded into the agent).
+   - Git or filesystem detection (`git symbolic-ref refs/remotes/origin/HEAD`, presence of `mise.toml` / `Makefile` / `package.json`, existence of `docs/superpowers/specs` etc.).
+   - Ask the user. Never guess.
+
+A field that no source provides and the active step needs stops the workflow with a question.
+
+## Non-negotiables
+
+See `references/invariants.md` for the full list. Summary:
+
+1. PR behavior respects `Mode`. Default never auto-merges.
+2. Never skip hooks (`--no-verify`, `--no-gpg-sign`, `LEFTHOOK=0`).
+3. No AI attribution in commits, PRs, or code.
+4. Conventional Commits compliance.
+5. No em-dashes or en-dashes in prose.
+6. Never synthesize a skill's output freehand.
+
+## Required skill invocations
+
+Read `references/required-skills.md` for the full table and `replaces` / `additional` semantics. The pre-PR audit (after step 6, before step 7) walks the merged table.
+
+| Step | Universal skill |
+|---|---|
+| 0 | `workbench:using-workbench` |
+| 2 | `workbench:brainstorming` |
+| 4 | `superpowers:writing-plans` |
+| 5 | `superpowers:test-driven-development` and `superpowers:subagent-driven-development` |
+| 6 | `claude-md-management:revise-claude-md` and `claude-md-management:claude-md-improver` |
+
+If a listed skill is unavailable in the current runtime, say so explicitly in the end-of-turn summary and skip only that entry. Never silently drop a row.
+
+## Runtime adapters
+
+This skill uses Claude Code tool names by default. If running on Codex, see `references/codex-adapter.md` for the tool-name mapping and the sequential-fallback note for subagent-driven-development. For Claude Code specifics (subagent dispatch patterns, CI polling shape, error recovery), see `references/claude-code-adapter.md`.
+
+---
+
+## Steps
+
+### Step 0: Establish skill discipline
+
+**First action:** invoke `workbench:using-workbench` via the `Skill` tool. Nothing else happens until the skill returns.
+
+If the profile's `## Required skills` table replaces this row with a different skill, invoke that one instead.
+
+### Step 1: Prepare the workspace
+
+- `git checkout <default branch> && git pull origin <default branch>` to get the latest.
+- If the local branch diverges from origin (for example after a squash merge), `git reset --hard origin/<default branch>`. Check with the user first if there are unpushed local commits.
+- Create a new branch: `git checkout -b <type>/<short-topic-slug>`. Use a Conventional-Commits type prefix (`feat/...`, `fix/...`, `docs/...`, etc.).
+
+`<default branch>` resolves through the bootstrap precedence chain.
+
+### Step 2: Brainstorm (sequential, self-answered)
+
+**First action:** wipe the scratch dir from any prior run, then invoke `workbench:brainstorming` via the `Skill` tool. Keep the skill's "one question at a time" rhythm, but self-answer each question instead of waiting for the user; autonomous mode removes the pause, not the sequencing.
+
+```bash
+rm -rf /tmp/<project-name>-brainstorm && mkdir -p /tmp/<project-name>-brainstorm
+```
+
+`<project-name>` resolves through the bootstrap precedence chain (profile `## Project name` heading; otherwise repo dir basename).
+
+Work the Q&A incrementally:
+
+- Start `/tmp/<project-name>-brainstorm/brainstorm.md` with a short preamble (topic, autonomous-mode note) before the first question.
+- For each question, in order:
+  1. Formulate the question you would have asked the user. Make it multiple-choice when possible.
+  2. Answer it yourself: list the options you considered, the decision, and the reasoning.
+  3. Append the Q&A as `## Q<n>. <question>` with the answer below.
+  4. Let the answer shape the next question.
+- Continue until scope, approach, file layout, commit split, risks, and success criteria are settled.
+- End with a `## Decision` block summarizing the PR shape.
+
+If the topic is too big for one spec, stop and surface the decomposition for the user to pick a sub-topic.
+
+**Format verify gate.** Before leaving step 2:
+
+```bash
+grep -c '^## Q' /tmp/<project-name>-brainstorm/brainstorm.md
+grep -c '^## Decision' /tmp/<project-name>-brainstorm/brainstorm.md
+```
+
+The first count must be greater than zero and match the number of questions answered. The second must be exactly 1. If either check fails, the Q&A was written with inline `Q1:` style instead of top-level `## Q<n>` headings; fix the file now. (If the profile defines a `post_pr` hook that parses brainstorm headings, mis-formatting surfaces only after PR open and forces a mid-PR reformat.)
+
+### Step 3: Write the spec
+
+- Use the spec template that `workbench:brainstorming` surfaced in step 2.
+- Path: `<paths.specs>/YYYY-MM-DD-<topic>-design.md`. `<paths.specs>` resolves through the bootstrap precedence chain.
+- Run the spec self-review: placeholders, internal consistency, scope, ambiguity. Fix inline.
+- Commit: `docs: add <topic> design spec`.
+
+If `Hooks.post_spec` is defined in the profile, run it now with `{{spec_path}}` substituted to the spec path.
+
+### Step 4: Write the implementation plan
+
+**First action:** invoke `superpowers:writing-plans` via the `Skill` tool. (If the profile replaces this row, invoke the replacement.)
+
+Then:
+
+- Path: `<paths.plans>/YYYY-MM-DD-<topic>.md`.
+- Use checkbox syntax (`- [ ]`) per task step so progress is trackable.
+- Commit: `docs: add <topic> implementation plan`.
+
+If `Hooks.post_plan` is defined, run it now with `{{plan_path}}` substituted.
+
+### Step 5: Execute the plan
+
+**First actions, in order:** invoke `superpowers:test-driven-development`, then `superpowers:subagent-driven-development`. Both via the `Skill` tool. (Replace either if the profile says so.) TDD governs every implementation chunk; subagent-driven-development governs how those chunks run.
+
+**Subagent dispatch (Claude Code):** see `references/claude-code-adapter.md` for the full pattern. Summary:
+
+- Independent tasks (no shared files, no ordering dependency): multiple `Agent` calls in one message.
+- Shared-state tasks: one agent at a time, sequential.
+- Trivial polish (rename one symbol, one-line lint fix): main session if files are already loaded; otherwise a subagent.
+
+**Subagent dispatch (Codex):** see `references/codex-adapter.md`. Use Codex's task or subagent equivalent if installed; else execute tasks sequentially in the main session with explicit context-reset discipline.
+
+Each subagent prompt must include: the plan task it owns (paste the checkbox block), which files to touch, the relevant commits that preceded it, the acceptance criteria.
+
+**Project-specific rebuild discipline.** When the profile's `## Project-specific rules` requires a rebuild or regen step before tests (for example "rebuild PyO3 binding before pytest"), include that step in the subagent's prompt as an explicit acceptance criterion. Otherwise the subagent observes phantom errors from stale artifacts.
+
+Then:
+
+- Commit in logical chunks with Conventional Commits scopes matching the module.
+- Run `<task runner> <lint command>` and the relevant `<task runner> <test command>` before each commit.
+
+If `Hooks.post_implementation` is defined, run it now after the last implementation commit.
+
+### Step 6: Finalize docs and improvement pass
+
+**First actions, in order:** invoke `claude-md-management:revise-claude-md`, then `claude-md-management:claude-md-improver`. Both via the `Skill` tool. (Replace either if the profile says so.)
+
+**Autonomous mode: apply every skill's proposed edits directly.** Do not pause for approval; running autopilot is the approval. Briefly report the edits in the end-of-turn summary so the user can see what landed.
+
+All edits land on the feature branch in this run. CLAUDE.md updates, ADRs, OPEN_THINGS updates, auto-memory updates: each one a commit on the current branch with a matching Conventional-Commits type. No follow-up chore PRs.
+
+Then:
+
+- Update `<paths.adr>/NNNN-<short-title>.md` for load-bearing decisions if the path exists in the project. Index in `<paths.adr>/README.md`.
+- Update `<paths.open_things>` if it exists: remove resolved items, add follow-ups ordered by importance.
+- Update other project doc files that drifted (architecture overview, README commands table).
+- Refresh user auto-memory entries for this project.
+
+### Skill audit (between step 6 and step 7, blocking)
+
+Re-read `references/required-skills.md` and the profile's `## Required skills` section. Walk every row in the merged table:
+
+1. For each universal row, confirm the corresponding skill was invoked via the `Skill` tool this session. If the profile replaces a row, audit the replacement instead.
+2. For each `additional` row from the profile, confirm that skill was also invoked.
+3. Re-read the profile's `## Project-specific rules` section. If any rule names a skill or command that should have been invoked, confirm it was.
+4. Re-read the project's `CLAUDE.md` and `AGENTS.md`. If either documents skill discipline naming a specific skill at a specific point, confirm that was invoked.
+
+If any required invocation is missing: invoke the skill now, let it reshape the artifact it governs, commit the correction, and only then proceed.
+
+The audit is blocking; do not push until it passes.
+
+### Step 7: Open the PR
+
+After the audit passes:
+
+- Push: `git push -u <git remote, default origin> <branch>`. If the project documents a wrapper (for example `mise exec --` for pinned hooks), use it.
+- Create the PR: `gh pr create --base <base branch> --title "<Conventional-Commits title>" --body "<body>"`.
+- PR body structure: `## Summary` (1-3 bullets), then scope or non-goals if relevant, `## Test plan` checklist, links to spec + plan + ADR if present.
+
+If `Hooks.post_pr` is defined, run it now with `{{pr}}` substituted to the PR number.
+
+### Step 8: CI loop
+
+Poll until every check resolves. Use the runtime adapter's polling primitive (Claude Code: `Monitor`; Codex: `run_in_background` plus sleep, or Codex's equivalent).
+
+Programmatic poll:
+
+```bash
+gh pr view <pr> --json statusCheckRollup -q '.statusCheckRollup[] | "\(.status):\(.conclusion // "")"'
+```
+
+Loop until no row's status differs from `COMPLETED` and no `conclusion` is `FAILURE`, `CANCELLED`, or `TIMED_OUT`. (`gh pr checks <pr>` is human-readable; do not pass `--json` to it, the flag does not exist on `gh pr checks`.)
+
+If a check fails: `gh run view <run-id> --log-failed | tail -200`, diagnose, commit the fix, push. Repeat until green.
+
+If `Hooks.post_ci_green` is defined, run it now once everything is green.
+
+### Step 9: Apply PR-behavior policy
+
+Branch on `Mode` from the profile.
+
+**`stop_at_green`** (default):
+
+- Report the PR URL in the end-of-turn summary.
+- Stop. Do not merge.
+
+**`automerge`:**
+
+1. Set automerge:
+
+   ```bash
+   gh pr merge <pr> --auto --squash
+   ```
+
+   Use `--squash` if `Squash: yes` (default), `--merge` if `Squash: no`.
+
+2. Poll for merge:
+
+   ```bash
+   gh pr view <pr> --json state -q .state
+   ```
+
+   Until it returns `MERGED`. If it returns `CLOSED` without merging, branch protection blocked the merge; surface the reason to the user instead of retrying.
+
+3. Refresh local default branch:
+
+   ```bash
+   git checkout <default branch>
+   git pull origin <default branch>
+   git branch -d <feature-branch>
+   ```
+
+   The lowercase `-d` refuses to delete an unmerged branch; if it fails, inspect before forcing.
+
+4. Report the merged commit hash and PR URL in the end-of-turn summary.
+
+**`request_review`:**
+
+- `gh pr ready <pr>`.
+- Post a one-line reviewer note as a PR comment.
+- Stop. Report the PR URL.
+
+If the user explicitly says "don't merge" before or during the run, override `automerge` to `request_review` for this run only; do not modify the profile.
+
+---
+
+## Tone and reporting
+
+- Terse between tool calls. The user sees the PR diff; they don't need narration.
+- End-of-turn summary: PR URL, one sentence on what changed, next step (usually "review when ready" or, for automerge, "merged at <commit>"). Also list any required skill that was unavailable in the runtime and therefore skipped.
+- If you hit an unexpected fork in the road that truly needs the user (not a routine choice), stop and ask. But bias strongly toward deciding yourself; that is the point of autopilot.

--- a/plugins/workbench/skills/autopilot/references/claude-code-adapter.md
+++ b/plugins/workbench/skills/autopilot/references/claude-code-adapter.md
@@ -1,0 +1,83 @@
+# Claude Code Adapter for Workbench Autopilot
+
+This doc maps the autopilot skill's tool references to Claude Code tool names and documents Claude-Code-specific patterns. Read alongside `SKILL.md`.
+
+## Tool name mapping
+
+| `SKILL.md` reference | Claude Code tool |
+|---|---|
+| Skill invocation | `Skill` |
+| Subagent dispatch | `Agent` with `subagent_type=general-purpose` for plan tasks |
+| Background process / CI polling | `Monitor` for stream-style polling; `run_in_background` for fire-and-forget |
+| Shell | `Bash` |
+| File ops | `Read`, `Write`, `Edit` |
+| GitHub | `gh` (via `Bash`) |
+
+## Subagent dispatch pattern (step 5)
+
+Plan tasks dispatch through `Agent` with `subagent_type=general-purpose`. Three regimes:
+
+### Independent tasks (parallel)
+
+No shared files, no ordering dependency. Send multiple `Agent` calls in a single message; they run in parallel.
+
+Typical examples:
+
+- Per-package documentation updates that touch different package directories.
+- Independent refactors in unrelated modules.
+- Multiple entity-page redesigns that do not edit the same i18n catalog.
+
+### Shared-state tasks (sequential)
+
+Tasks that touch the same i18n catalog, the same `app.css`, the same shared route tree, or the same component file. Dispatch one agent at a time, waiting for each to return before dispatching the next. One agent per task; they queue instead of fan out.
+
+Tip: if you can batch all edits to a shared file into a single prep task, the remaining tasks become independent and can run in parallel.
+
+### Trivial polish (main session)
+
+Renaming one symbol, a one-line lint fix, a typo. Use a subagent if the work touches files the main session has not loaded. Skip the subagent only when the main session just made the surrounding edit and still has the file in context.
+
+## Subagent prompt requirements
+
+Each subagent prompt must include:
+
+- The plan task it owns. Paste the checkbox block from the plan.
+- Which files to touch.
+- Relevant commits that preceded it (one-line summary each).
+- Acceptance criteria: tests to run, lint to pass, project-specific rules from the profile that apply.
+
+The main session reviews the agent's diff and commits. The agent should not commit on its own.
+
+## Subagent error recovery
+
+If a subagent errors mid-run (for example "Overloaded"), it may have written files without committing. Before dispatching a continuation:
+
+1. From the main session, run `git status` and `git diff` to see what partial work survived.
+2. If the partial work is mostly correct, continue in the main session rather than redispatching. The main session is usually cheaper than retrying when the agent already did the heavy edit.
+3. Include a brief "Continuing from subagent state" note in the next commit's body so the review trail is legible.
+
+If a subagent reports `DONE_WITH_CONCERNS` and the concern is in-scope (perf-budget regression, unfixed lint, missing test), fix it before committing, either in the main session or by re-dispatching with the gap added to the acceptance criteria. Do not carry the concern into the PR.
+
+## CI polling shape (step 8)
+
+Use `Monitor` to stream `gh pr view` JSON until checks resolve:
+
+```bash
+gh pr view <pr> --json statusCheckRollup -q '.statusCheckRollup[] | "\(.status):\(.conclusion // "")"'
+```
+
+Loop until no row's status differs from `COMPLETED` and no conclusion is `FAILURE`, `CANCELLED`, or `TIMED_OUT`.
+
+For human-readable status, `gh pr checks <pr>` works; do not pass `--json` to it (the flag does not exist there). For programmatic polling, the JSON form on `gh pr view` is correct.
+
+## Common Claude Code failure modes
+
+- **`Monitor` consumes context fast.** For long-running CI loops, prefer a tighter poll interval and exit early once the rollup resolves.
+- **`Agent` cost.** Each `Agent` invocation has overhead. For tasks the main session can do quickly with files already loaded, do not spawn a subagent purely for hygiene.
+- **`gh` auth.** Assume `gh` is already authenticated. If it is not, surface that to the user instead of trying to authenticate inside autopilot.
+
+## See also
+
+- `SKILL.md`: the autopilot orchestration.
+- `codex-adapter.md`: the Codex-side mapping.
+- `../using-workbench/references/codex-tools.md`: broader Codex tool table.

--- a/plugins/workbench/skills/autopilot/references/codex-adapter.md
+++ b/plugins/workbench/skills/autopilot/references/codex-adapter.md
@@ -1,0 +1,56 @@
+# Codex Adapter for Workbench Autopilot
+
+This doc maps the autopilot skill's tool references to Codex equivalents. The autopilot `SKILL.md` uses Claude Code tool names by default; this adapter is consulted when the runtime is Codex.
+
+## Tool name mapping
+
+| `SKILL.md` reference | Codex equivalent |
+|---|---|
+| `Skill` | `skill` |
+| `Agent` (subagent) | Codex's task or subagent equivalent if installed; otherwise sequential execution in the main session (see below) |
+| `Monitor` | `run_in_background` plus a polling loop, or Codex's monitoring primitive if present |
+| `Bash`, `Read`, `Write`, `Edit` | Equivalent Codex tools (see `../using-workbench/references/codex-tools.md` for the broader table) |
+| `gh` | Same; invoked via the shell tool |
+
+## Subagent strategy on Codex
+
+`superpowers:subagent-driven-development` is best-effort on Codex. The autopilot expects a fresh subagent per plan task. If Codex's runtime exposes such a primitive, use it. If it does not, fall back to **sequential execution in the main session with explicit context-reset discipline**:
+
+1. Treat each plan task as its own logical scope.
+2. Before starting a task, write a one-line context-reset note: `--- starting task <n>: <title> ---`. This is for legibility, not behavior.
+3. Execute the task end-to-end (write code, run tests, commit) before moving to the next.
+4. After completing a task, write a one-line note: `--- completed task <n> ---`.
+5. Continue with the next task.
+
+Sequential fallback gives up the parallelism of independent tasks but preserves the per-task discipline of subagent-driven-development.
+
+## CI polling shape (step 8)
+
+Use `run_in_background` to launch the polling loop, or Codex's monitoring primitive if it has one. The query is the same:
+
+```bash
+gh pr view <pr> --json statusCheckRollup -q '.statusCheckRollup[] | "\(.status):\(.conclusion // "")"'
+```
+
+Loop with a sleep interval that respects Codex's runtime budget; aim for 30-60 seconds between polls during normal CI runs.
+
+## Subagent error recovery
+
+If Codex's subagent primitive errors, recover the same way as Claude Code: from the main session, inspect partial work via `git status` / `git diff`, continue in the main session if the partial work survived, note "Continuing from subagent state" in the next commit body.
+
+## Common Codex caveats
+
+- **No `Monitor` equivalent in some runtimes.** Use the polling fallback; do not skip step 8.
+- **Tool names are case-sensitive.** `skill` is lowercase on Codex; `Skill` is uppercase on Claude Code.
+- **Same `gh` and `git` semantics.** GitHub CLI behavior is identical; Conventional Commits enforcement still applies.
+
+## What this adapter does NOT cover
+
+- A live Codex CI test of autopilot's flow. Adapter docs ship in PR 2; runtime-parity validation is future work (see the spec's "Future work" section).
+- Auto-detection of which runtime is active inside `SKILL.md`. The agent reads the appropriate adapter doc based on the runtime they know they are running in.
+
+## See also
+
+- `SKILL.md`: the autopilot orchestration.
+- `claude-code-adapter.md`: the Claude Code side.
+- `../using-workbench/references/codex-tools.md`: broader Codex tool table.

--- a/plugins/workbench/skills/autopilot/references/invariants.md
+++ b/plugins/workbench/skills/autopilot/references/invariants.md
@@ -1,0 +1,39 @@
+# Workbench Autopilot Invariants
+
+Six non-negotiables that govern every autopilot run. Profiles can extend through `## Project-specific rules` but cannot weaken these.
+
+## 1. PR behavior respects `Mode`
+
+The `Mode` field in the project's `.workbench/autopilot.md` determines the post-CI behavior:
+
+- `stop_at_green` (default): autopilot stops when CI is green and reports the PR URL.
+- `automerge`: autopilot calls `gh pr merge --auto`, polls until merged, refreshes local default branch, deletes the feature branch.
+- `request_review`: autopilot calls `gh pr ready` and stops.
+
+Default never auto-merges. Autopilot never assumes automerge unless the profile explicitly opts in.
+
+## 2. Never skip hooks
+
+No `--no-verify`, no `--no-gpg-sign`, no `LEFTHOOK=0`, no environment variables that bypass git hooks. If a hook fails, investigate the underlying issue and fix it. Skipping the hook is never the right answer.
+
+## 3. No AI attribution
+
+No `Generated with`, no `Co-Authored-By: Claude`, no AI provenance lines anywhere in commit messages, PR titles, PR bodies, or code comments. The user prefers attribution to themselves.
+
+## 4. Conventional Commits compliance
+
+Every commit subject uses a Conventional Commits type. Allowed types (defaults; the profile may shrink the set via prose, never grow it):
+
+`feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `style`, `ci`, `build`, `revert`.
+
+Lowercase subject after the colon. Scope is optional but recommended.
+
+## 5. No em-dashes or en-dashes in prose
+
+User global preference. Rewrite with commas, periods, colons, semicolons, parentheses, or by splitting into separate sentences. Hyphens in compound words (`spec-driven`, `AI-assisted`) are hyphenation, not punctuation, and stay. Markdown horizontal rules (`---`) are structural and stay.
+
+## 6. Never synthesize a skill's output freehand
+
+When a step names a skill, calling the `Skill` tool (or its runtime equivalent) and letting it return is mandatory before producing that step's artifact. Freehand output that looks like a skill ran is a process violation; the work must be redone after invoking the skill.
+
+At the end of each turn, double-check that the skills required by the steps you just executed actually appear in your tool-call history. The pre-PR audit (between step 6 and step 7) re-walks the universal required-skills table and the profile's overrides; missing invocations block the push.

--- a/plugins/workbench/skills/autopilot/references/required-skills.md
+++ b/plugins/workbench/skills/autopilot/references/required-skills.md
@@ -1,0 +1,72 @@
+# Workbench Autopilot Required Skills
+
+The universal table that the autopilot skill walks at the pre-PR audit. Profiles can extend or replace rows through a `## Required skills` section in `.workbench/autopilot.md`, but cannot remove rows.
+
+## Universal table (defaults)
+
+| Step | Skill | Notes |
+|---|---|---|
+| 0 | `workbench:using-workbench` | session-start meta, workbench-native fork |
+| 2 | `workbench:brainstorming` | already ported into workbench |
+| 4 | `superpowers:writing-plans` | not yet ported into workbench |
+| 5 | `superpowers:test-driven-development` | not yet ported |
+| 5 | `superpowers:subagent-driven-development` | not yet ported |
+| 6 | `claude-md-management:revise-claude-md` | cross-plugin |
+| 6 | `claude-md-management:claude-md-improver` | cross-plugin |
+
+These are the rows shipped with workbench v0.2.0. As more skills are ported into workbench, this table flips them to `workbench:*`.
+
+`fewer-permission-prompts` is intentionally not in the universal table. It is Claude-Code-specific (touches `.claude/settings.json`) and an optimization rather than a discipline gate. Projects that want it can add it via `additional` (see below).
+
+## Replace and additional semantics
+
+Profiles override the table through a `## Required skills` heading shaped like this:
+
+```md
+## Required skills
+| Step | Skill | Action |
+|---|---|---|
+| <n> | <skill-id> | replaces <existing-skill-id> |
+| <n> | <skill-id> | additional |
+```
+
+### Replace
+
+A row whose `Action` column says `replaces <skill-id>` swaps which skill fulfills an existing step. The audit walks the replacement instead of the universal row.
+
+Example:
+
+```md
+| 4 | workbench:writing-plans | replaces superpowers:writing-plans |
+```
+
+This says "for step 4, audit `workbench:writing-plans` instead of `superpowers:writing-plans`." The other six universal rows are unchanged.
+
+### Additional
+
+A row whose `Action` column is `additional` adds a new mandatory skill at a step. The audit walks the universal row(s) for that step AND the additional row.
+
+Example:
+
+```md
+| 6 | my-project:custom-changelog | additional |
+```
+
+This says "at step 6, in addition to `revise-claude-md` and `claude-md-improver`, also audit `my-project:custom-changelog`."
+
+### Removal not supported
+
+Profiles cannot remove a row from the universal table. The discipline floor is fixed across projects.
+
+## Audit walk
+
+At the pre-PR audit (between step 6 and step 7):
+
+1. Read the universal table from this file.
+2. Read the profile's `## Required skills` section if present.
+3. For each universal row, if the profile has a `replaces` row matching the step and target, audit the replacement; otherwise audit the universal row.
+4. Audit any `additional` rows from the profile.
+5. Re-read the profile's `## Project-specific rules` section. If any rule names a skill or command that should have been invoked, confirm it was.
+6. Re-read the project's `CLAUDE.md` and `AGENTS.md`. If either documents skill discipline naming a specific skill at a specific step, confirm it was invoked.
+
+If any required invocation is missing: invoke the skill now, let it reshape the artifact it governs, commit the correction, and only then proceed to step 7.

--- a/tests/skill-triggering/prompts/autopilot-autonomous.txt
+++ b/tests/skill-triggering/prompts/autopilot-autonomous.txt
@@ -1,0 +1,1 @@
+Autonomously implement and ship a feature that adds CSV export to the report page, all the way through to a green CI build.

--- a/tests/skill-triggering/prompts/autopilot-feature.txt
+++ b/tests/skill-triggering/prompts/autopilot-feature.txt
@@ -1,0 +1,1 @@
+Use autopilot to ship the new dashboard widget feature end-to-end.

--- a/tests/skill-triggering/prompts/autopilot-no-trigger-plan-only.txt
+++ b/tests/skill-triggering/prompts/autopilot-no-trigger-plan-only.txt
@@ -1,0 +1,1 @@
+Write an implementation plan for refactoring the auth module.

--- a/tests/skill-triggering/prompts/autopilot-no-trigger-spec-only.txt
+++ b/tests/skill-triggering/prompts/autopilot-no-trigger-spec-only.txt
@@ -1,0 +1,1 @@
+Write a spec for the new dashboard layout.

--- a/tests/unit/test-workbench-autopilot-skill.sh
+++ b/tests/unit/test-workbench-autopilot-skill.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Test: workbench:autopilot skill structure
+# Verifies PR 2 of the autopilot port: SKILL.md exists, references all six refs,
+# names every universal skill, has all ten step headings, and the plugin manifests
+# are at 0.2.0.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/autopilot"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+echo "=== Test: workbench:autopilot skill structure ==="
+echo ""
+
+# Test 1: SKILL.md exists with frontmatter
+echo "Test 1: SKILL.md exists with frontmatter..."
+if [ -s "$SKILL_MD" ]; then
+    if head -1 "$SKILL_MD" | grep -q '^---$'; then
+        echo "  [PASS] SKILL.md exists with frontmatter"
+    else
+        echo "  [FAIL] SKILL.md missing frontmatter"
+        exit 1
+    fi
+else
+    echo "  [FAIL] SKILL.md missing or empty"
+    exit 1
+fi
+echo ""
+
+# Test 2: All six reference files exist
+echo "Test 2: Reference files exist..."
+for ref in profile-schema example-project-profile invariants required-skills claude-code-adapter codex-adapter; do
+    f="$SKILL_DIR/references/$ref.md"
+    if [ -s "$f" ]; then
+        echo "  [PASS] references/$ref.md exists"
+    else
+        echo "  [FAIL] references/$ref.md missing or empty"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 3: SKILL.md mentions all six reference files
+echo "Test 3: SKILL.md references all six reference files..."
+for ref in profile-schema example-project-profile invariants required-skills claude-code-adapter codex-adapter; do
+    if grep -qF "$ref" "$SKILL_MD"; then
+        echo "  [PASS] SKILL.md mentions $ref"
+    else
+        echo "  [FAIL] SKILL.md missing reference to $ref"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 4: SKILL.md mentions .workbench/autopilot.md
+echo "Test 4: SKILL.md mentions .workbench/autopilot.md..."
+if grep -qF '.workbench/autopilot.md' "$SKILL_MD"; then
+    echo "  [PASS] SKILL.md mentions .workbench/autopilot.md"
+else
+    echo "  [FAIL] SKILL.md missing .workbench/autopilot.md"
+    exit 1
+fi
+echo ""
+
+# Test 5: SKILL.md mentions every skill in the universal table
+echo "Test 5: SKILL.md mentions every universal skill..."
+for skill in 'workbench:using-workbench' 'workbench:brainstorming' 'superpowers:writing-plans' 'superpowers:test-driven-development' 'superpowers:subagent-driven-development' 'claude-md-management:revise-claude-md' 'claude-md-management:claude-md-improver'; do
+    if grep -qF "$skill" "$SKILL_MD"; then
+        echo "  [PASS] SKILL.md mentions $skill"
+    else
+        echo "  [FAIL] SKILL.md missing $skill"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 6: All ten step headings present
+echo "Test 6: All ten step headings present..."
+for n in 0 1 2 3 4 5 6 7 8 9; do
+    if grep -qE "^### Step $n[: ]" "$SKILL_MD"; then
+        echo "  [PASS] Step $n heading present"
+    else
+        echo "  [FAIL] Step $n heading missing"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 7: invariants.md lists six non-negotiables
+echo "Test 7: invariants.md lists six non-negotiables..."
+INV="$SKILL_DIR/references/invariants.md"
+HEADINGS=$(grep -cE '^## [0-9]+\. ' "$INV" || true)
+if [ "$HEADINGS" -eq 6 ]; then
+    echo "  [PASS] invariants.md has six numbered headings"
+else
+    echo "  [FAIL] invariants.md has $HEADINGS numbered headings (expected 6)"
+    exit 1
+fi
+for term in 'PR behavior' 'hooks' 'AI attribution' 'Conventional Commits' 'em-dash' 'freehand'; do
+    if grep -qiF "$term" "$INV"; then
+        echo "  [PASS] invariants mentions $term"
+    else
+        echo "  [FAIL] invariants missing $term"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 8: required-skills.md complete
+echo "Test 8: required-skills.md complete..."
+RS="$SKILL_DIR/references/required-skills.md"
+for term in 'workbench:using-workbench' 'workbench:brainstorming' 'replaces' 'additional' 'Removal not supported'; do
+    if grep -qF "$term" "$RS"; then
+        echo "  [PASS] required-skills mentions $term"
+    else
+        echo "  [FAIL] required-skills missing $term"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 9: Adapter docs runtime-correct
+echo "Test 9: Adapter docs..."
+CC="$SKILL_DIR/references/claude-code-adapter.md"
+CX="$SKILL_DIR/references/codex-adapter.md"
+if grep -qF 'Agent' "$CC" && grep -qF 'Monitor' "$CC" && grep -qiF 'subagent' "$CC"; then
+    echo "  [PASS] claude-code-adapter mentions Agent, Monitor, subagent"
+else
+    echo "  [FAIL] claude-code-adapter incomplete"
+    exit 1
+fi
+if grep -qF 'sequential' "$CX" && grep -qF 'fallback' "$CX"; then
+    echo "  [PASS] codex-adapter mentions sequential fallback"
+else
+    echo "  [FAIL] codex-adapter incomplete"
+    exit 1
+fi
+echo ""
+
+# Test 10: Description triggers correctly
+echo "Test 10: Description trigger phrases..."
+desc=$(awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag' "$SKILL_MD")
+if echo "$desc" | grep -qiE 'autonomous|autopilot|end-to-end'; then
+    echo "  [PASS] description mentions autonomous/autopilot/end-to-end"
+else
+    echo "  [FAIL] description missing key trigger phrase"
+    exit 1
+fi
+if echo "$desc" | grep -qF '.workbench/autopilot.md'; then
+    echo "  [PASS] description mentions .workbench/autopilot.md"
+else
+    echo "  [FAIL] description missing .workbench/autopilot.md"
+    exit 1
+fi
+echo ""
+
+# Test 11: Plugin manifests at 0.2.0
+echo "Test 11: Plugin manifests at 0.2.0..."
+CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
+CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
+if jq -e '.version == "0.2.0"' "$CCM" >/dev/null && jq -e '.version == "0.2.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.2.0"
+else
+    echo "  [FAIL] plugin manifests not at 0.2.0"
+    exit 1
+fi
+echo ""
+
+# Test 12: Marketplace entries at 0.2.0
+echo "Test 12: Marketplace entries..."
+MP="$REPO_ROOT/.claude-plugin/marketplace.json"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.2.0"' "$MP" >/dev/null; then
+    echo "  [PASS] Claude marketplace workbench at 0.2.0"
+else
+    echo "  [FAIL] Claude marketplace workbench not at 0.2.0"
+    exit 1
+fi
+echo ""
+
+echo "=== Tests complete ==="


### PR DESCRIPTION
## Summary

Adds the generic `workbench:autopilot` skill that consumes the project profile from PR 1 and runs the ten-step autonomous PR flow with a pre-PR skill audit, profile-controlled PR behavior, and runtime adapter docs for Claude Code and Codex. This is PR 2 of 2 in the autopilot port (issue #23).

- New `SKILL.md` orchestrator with the ten steps inline plus an embedded audit gate.
- New `references/invariants.md`: six non-negotiables (PR behavior, hooks, AI attribution, Conventional Commits, em-dashes, never synthesize a skill).
- New `references/required-skills.md`: universal audit table plus replace/additional semantics.
- New `references/claude-code-adapter.md` and `references/codex-adapter.md`: runtime tool mappings; Codex documents the sequential-fallback pattern when no subagent primitive exists.
- Plugin manifest version bump 0.1.0 to 0.2.0 in both `.claude-plugin` and `.codex-plugin`; marketplace entries updated.
- Unit test pins SKILL.md structure, reference completeness, and version.
- Four skill-triggering prompts (two positive, two negative).

Spec: `docs/superpowers/specs/2026-05-05-workbench-autopilot-port-design.md` (sections "PR 2: generic autopilot skill" through "Testing").

PR 3 (Klassenzeit migration) is owner-handled and out of scope.

## Test plan

- [x] `bash tests/unit/test-workbench-autopilot-skill.sh` passes locally
- [ ] CI passes
- [x] `bash tests/unit/test-codex-plugin-structure.sh` passes (plugin manifest still valid)
- [x] Skill-triggering smoke (live Claude): both positive prompts triggered autopilot; both negative prompts did not trigger it
- [ ] Workbench README and root README still render correctly (PR 1 already shipped these)

## Future work (recorded in spec)

- Extract automerge cleanup into `workbench:finishing-a-development-branch` (file as new issue once this lands).
- Port remaining required skills into workbench (`workbench:writing-plans`, etc.); each port flips a row in `required-skills.md`.
- Codex CI parity test for the adapter doc.
- AGENTS.md / CLAUDE.md / README.md fallback discovery.