### PR TITLE
Bump plugin versions for skill frontmatter fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
       "name": "writing",
       "source": "./plugins/writing",
       "description": "Multi-phase writing pipeline with panel-of-critics review for blog posts, essays, talks, and longer-form prose. Format-aware: Smart-Brevity critic added for memo/newsletter/announcement formats. Ships a dedicated Pyramid Principle skill (Barbara Minto) with three construction modes (greenfield, restructure, Socratic). Also ships a Diátaxis-aware tech-doc skill for tutorials, how-to guides, references, and explanations, with full transcriptions of the Microsoft and Google style guides via a modular sidecar architecture (core, wordlist, procedures, admonitions, code-samples, links, numbers, api-reference) and an eight-critic panel.",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     {
       "name": "runtime-bridge",
@@ -38,7 +38,7 @@
       "name": "agents-md-management",
       "source": "./plugins/agents-md-management",
       "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "name": "workbench",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ tests/
 | `atlassian` | 2.0.0 | `jira`, `confluence` |
 | `google-workspace` | 1.0.0 | `gmail`, `calendar` |
 | `research` | 2.0.0 | `research` (multi-agent pipeline with review gates) |
-| `writing` | 1.6.0 | `writing`, `pyramid`, `tech-doc` |
+| `writing` | 1.6.1 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
-| `agents-md-management` | 0.1.0 | `agents-md-improver`, `agents-md-session-capture` |
+| `agents-md-management` | 0.1.1 | `agents-md-improver`, `agents-md-session-capture` |
 | `workbench` | 0.1.0 | `brainstorming`, `using-workbench` |
 
 ## How to Develop a New Skill

--- a/plugins/agents-md-management/.claude-plugin/plugin.json
+++ b/plugins/agents-md-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-md-management",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Audit and maintain AGENTS.md / CLAUDE.md files across project and user-global scopes; capture session learnings into the right file by scope.",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/agents-md-management/.codex-plugin/plugin.json
+++ b/plugins/agents-md-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-md-management",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Audit and maintain AGENTS.md / CLAUDE.md files; capture session learnings",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/writing/.claude-plugin/plugin.json
+++ b/plugins/writing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "writing",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Multi-phase writing pipeline with panel-of-critics review for blog posts, essays, talks, and longer-form prose. Also ships a dedicated Pyramid Principle skill for memos, recommendations, and analytical documents.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/writing/.codex-plugin/plugin.json
+++ b/plugins/writing/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "writing",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Writing, pyramid structure, and technical documentation skills.",
   "author": {
     "name": "Pascal Göllner"


### PR DESCRIPTION
## Summary

- Bump writing from 1.6.0 to 1.6.1 in Claude and Codex plugin metadata.
- Bump agents-md-management from 0.1.0 to 0.1.1 in Claude and Codex plugin metadata.
- Update the Claude marketplace and root plugin version table.

## Verification

- bash tests/unit/test-codex-plugin-structure.sh
- jq empty plugins/agents-md-management/.claude-plugin/plugin.json plugins/agents-md-management/.codex-plugin/plugin.json plugins/writing/.claude-plugin/plugin.json plugins/writing/.codex-plugin/plugin.json .claude-plugin/marketplace.json .agents/plugins/marketplace.json