### PR TITLE
[codex] add workbench terse mode skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ reports/
 .worktrees/
 docs/superpowers/
 notes/
+.claude/*.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ PLUGIN_DIR=plugins/<plugin> bash tests/integration/test-<service>-integration.sh
 
 # Skill triggering
 PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh <skill> tests/skill-triggering/prompts/<prompt>.txt
+PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh --not <skill> tests/skill-triggering/prompts/<prompt>.txt
 ```
 
 ## Design Decisions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ tests/
 | `writing` | 1.6.1 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.2.0 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
-| `workbench` | 0.5.0 | `brainstorming`, `writing-spec`, `visualizing-options`, `using-workbench`, `autopilot` |
+| `workbench` | 0.5.0 | `brainstorming`, `writing-spec`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot` |
 
 ## How to Develop a New Skill
 
@@ -207,7 +207,7 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh <skill> test
 ## Design Decisions
 
 - **No wrapper scripts.** Skills use the underlying CLI directly (`gws` for Google Workspace) or raw `curl` with env-var auth (for Atlassian). This keeps each skill self-contained — no extra bash layer to maintain, debug, or ship with the plugin.
-- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `visualizing-options`, `using-workbench`, `autopilot`) are peer phases of one workflow rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
+- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
 - **Skills are self-contained.** Each SKILL.md should contain everything the host agent needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Codex compatibility is metadata plus platform mapping.** Codex manifests live beside Claude Code manifests and point at the same `skills` directory. Platform-specific tool differences belong in the shared skill body as a mapping, not in duplicated skill files.
 - **Tests run Claude in a subprocess.** Unit tests use `run_claude` with `--dangerously-skip-permissions`. Integration tests use `run_claude_logged` with `--output-format stream-json` to capture tool usage.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `writing-spec` | workbench | Synthesize a design discussion into a spec doc |
 | `visualizing-options` | workbench | Browser-based visual companion for layout choices |
 | `using-workbench` | workbench | Load Workbench skill rules and routing |
+| `terse-mode` | workbench | Explicit session switch for compact token-saving replies |
 | `creating-skills` | agent-system-management | Scaffold, iterate, pressure-test, and tune skills across the full lifecycle |
 
 ## Plugins
@@ -84,6 +85,7 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 - `/pgoell-claude-tools:writing-spec`: Synthesize a design discussion into a spec doc, run a fresh-eyes self-review subagent, gate on user approval, then hand off to `superpowers:writing-plans`.
 - `/pgoell-claude-tools:visualizing-options`: Browser-based visual companion for mockups, layout comparisons, wireframes, and architecture diagrams. The user clicks to choose between options.
 - `/pgoell-claude-tools:using-workbench`: Load Workbench skill rules and routing.
+- `/pgoell-claude-tools:terse-mode`: Explicit session switch for compact token-saving replies until disabled with normal mode.
 - `/pgoell-claude-tools:autopilot`: Ship a feature from brainstorm to PR using a project profile.
 
 Autopilot profiles are documented in `plugins/workbench/skills/autopilot/references/profile-schema.md`.

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -6,6 +6,7 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 
 - `brainstorming`: Turn ideas into clear design decisions.
 - `using-workbench`: Load Workbench skill rules and routing.
+- `terse-mode`: Explicit session switch for compact token-saving replies.
 - `autopilot`: Ship a feature from brainstorm to PR using a project profile.
 
 ## Project profiles

--- a/plugins/workbench/skills/terse-mode/SKILL.md
+++ b/plugins/workbench/skills/terse-mode/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: terse-mode
+description: Use only when the user explicitly asks to switch the session into terse mode, terse-mode, less tokens mode, token saving mode, or /terse-mode.
+---
+
+# Terse Mode
+
+Switch future responses into a compact token-saving style until the user explicitly disables it.
+
+## Activation
+
+Activate this skill only for explicit session-switch requests such as:
+
+- `terse mode`
+- `use terse-mode`
+- `enable terse mode`
+- `less tokens mode`
+- `token saving mode`
+- `/terse-mode`
+
+Do not activate for ordinary writing or editing requests such as:
+
+- `be brief`
+- `be concise`
+- `make this shorter`
+- `tighten this copy`
+- `summarize this`
+- `write a concise version`
+
+Those requests apply to the current content only. They do not change the session style.
+
+## Persistence
+
+Once active, keep using terse mode in future turns until the user explicitly disables it.
+
+Disable terse mode when the user says:
+
+- `stop terse mode`
+- `disable terse mode`
+- `normal mode`
+- `stop token saving mode`
+- `use normal responses`
+
+After disabling, return to the host agent's normal response style.
+
+## Response Style
+
+Prefer:
+
+- Short replies.
+- Compact structure.
+- Fragments for simple answers when clear.
+- Direct verbs.
+- Obvious abbreviations where they improve clarity.
+- Arrows (`->`) for simple flows.
+- No filler, pleasantries, redundant setup, or needless hedging.
+
+Keep unchanged:
+
+- Code blocks.
+- Exact errors.
+- Command output.
+- File paths.
+- Quoted text.
+- User-provided wording that must stay exact.
+
+## Clarity Exceptions
+
+Temporarily expand when brevity could cause harm or confusion:
+
+- Security warnings.
+- Destructive or irreversible operations.
+- Multi-step procedures.
+- Legal, medical, financial, or safety-sensitive guidance.
+- User confusion or contradiction.
+- Explicit requests for clarification or detail.
+
+During an exception, stay concise but preserve clear grammar, explicit ordering, and full warnings. Resume terse mode after the exception is handled.
+
+## Behavioral Rules
+
+- Do not adopt a persona.
+- Do not mention unrelated inspiration or source names to the user.
+- Do not compress so hard that instructions become ambiguous.
+- Do not remove required confirmations before destructive operations.
+- Do not omit verification results when reporting completed work.

--- a/tests/skill-triggering/prompts/workbench-terse-mode-no-trigger-concise.txt
+++ b/tests/skill-triggering/prompts/workbench-terse-mode-no-trigger-concise.txt
@@ -1,0 +1,1 @@
+Make this paragraph concise without changing its meaning.

--- a/tests/skill-triggering/prompts/workbench-terse-mode-slug.txt
+++ b/tests/skill-triggering/prompts/workbench-terse-mode-slug.txt
@@ -1,0 +1,1 @@
+use /terse-mode

--- a/tests/skill-triggering/prompts/workbench-terse-mode.txt
+++ b/tests/skill-triggering/prompts/workbench-terse-mode.txt
@@ -1,0 +1,1 @@
+terse mode

--- a/tests/skill-triggering/prompts/workbench-token-saving-mode.txt
+++ b/tests/skill-triggering/prompts/workbench-token-saving-mode.txt
@@ -1,0 +1,1 @@
+enable token saving mode for this session

--- a/tests/skill-triggering/run-test.sh
+++ b/tests/skill-triggering/run-test.sh
@@ -7,6 +7,12 @@ REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export PLUGIN_DIR="${PLUGIN_DIR:-$REPO_DIR/plugins/atlassian}"
 cd "$REPO_DIR"
 
+NEGATIVE=false
+if [ "${1:-}" = "--not" ]; then
+    NEGATIVE=true
+    shift
+fi
+
 EXPECTED_SKILL="$1"
 PROMPT_FILE="$2"
 PROMPT="$(cat "$PROMPT_FILE")"
@@ -32,9 +38,20 @@ fi
 # Check if the skill was triggered
 SKILL_PATTERN="\"skill\":\"([^\"]*:)?${EXPECTED_SKILL}\""
 if grep -qE "$SKILL_PATTERN" "$LOG_FILE"; then
+    if $NEGATIVE; then
+        echo "  [FAIL] Skill '$EXPECTED_SKILL' was triggered"
+        echo "  Log file (first 500 chars):"
+        head -c 500 "$LOG_FILE" | sed 's/^/    /'
+        exit 1
+    fi
     echo "  [PASS] Skill '$EXPECTED_SKILL' was triggered"
 else
-    echo "  [FAIL] Skill '$EXPECTED_SKILL' was NOT triggered"
-    echo "  Log file (first 500 chars):"
-    head -c 500 "$LOG_FILE" | sed 's/^/    /'
+    if $NEGATIVE; then
+        echo "  [PASS] Skill '$EXPECTED_SKILL' was not triggered"
+    else
+        echo "  [FAIL] Skill '$EXPECTED_SKILL' was NOT triggered"
+        echo "  Log file (first 500 chars):"
+        head -c 500 "$LOG_FILE" | sed 's/^/    /'
+        exit 1
+    fi
 fi

--- a/tests/unit/test-workbench-terse-mode-skill.sh
+++ b/tests/unit/test-workbench-terse-mode-skill.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Test: workbench:terse-mode skill structure
+# Verifies narrow activation, persistence, disable phrases, clarity exceptions,
+# non-trigger guidance, and punctuation lint compatibility.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/terse-mode"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+echo "=== Test: workbench:terse-mode skill structure ==="
+
+# Test 1: SKILL.md exists with frontmatter
+if [ -s "$SKILL_MD" ] && head -1 "$SKILL_MD" | grep -q '^---$'; then
+    echo "[PASS] SKILL.md exists with frontmatter"
+else
+    echo "[FAIL] SKILL.md missing or no frontmatter"; exit 1
+fi
+
+# Test 2: Frontmatter name
+if grep -q '^name: terse-mode$' "$SKILL_MD"; then
+    echo "[PASS] frontmatter name is terse-mode"
+else
+    echo "[FAIL] frontmatter name missing"; exit 1
+fi
+
+# Test 3: Description stays narrow and explicit
+desc=$(awk '/^description:/{flag=1;sub(/^description:[ ]*/,"")} /^---$/{flag=0} flag' "$SKILL_MD")
+for phrase in 'explicitly asks' 'terse mode' 'token saving mode' '/terse-mode'; do
+    if echo "$desc" | grep -qiF "$phrase"; then
+        echo "[PASS] description mentions $phrase"
+    else
+        echo "[FAIL] description missing $phrase"; exit 1
+    fi
+done
+for broad in 'be brief' 'be concise' 'make this shorter' 'tighten this copy'; do
+    if echo "$desc" | grep -qiF "$broad"; then
+        echo "[FAIL] description includes broad non-trigger: $broad"; exit 1
+    else
+        echo "[PASS] description avoids broad non-trigger: $broad"
+    fi
+done
+
+# Test 4: Activation phrases are present
+for phrase in 'use terse-mode' 'enable terse mode' 'less tokens mode' 'token saving mode'; do
+    if grep -qiF "$phrase" "$SKILL_MD"; then
+        echo "[PASS] activation phrase present: $phrase"
+    else
+        echo "[FAIL] activation phrase missing: $phrase"; exit 1
+    fi
+done
+
+# Test 5: Persistence and disable behavior are present
+for phrase in 'future turns until the user explicitly disables it' 'stop terse mode' 'disable terse mode' 'normal mode' 'stop token saving mode'; do
+    if grep -qiF "$phrase" "$SKILL_MD"; then
+        echo "[PASS] persistence or disable phrase present: $phrase"
+    else
+        echo "[FAIL] persistence or disable phrase missing: $phrase"; exit 1
+    fi
+done
+
+# Test 6: Non-trigger guidance is present
+for phrase in 'be brief' 'be concise' 'make this shorter' 'tighten this copy' 'current content only'; do
+    if grep -qiF "$phrase" "$SKILL_MD"; then
+        echo "[PASS] non-trigger guidance present: $phrase"
+    else
+        echo "[FAIL] non-trigger guidance missing: $phrase"; exit 1
+    fi
+done
+
+# Test 7: Compression rules are present
+for phrase in 'No filler' 'Code blocks' 'Exact errors' 'Command output' 'File paths' 'Quoted text'; do
+    if grep -qiF "$phrase" "$SKILL_MD"; then
+        echo "[PASS] compression rule present: $phrase"
+    else
+        echo "[FAIL] compression rule missing: $phrase"; exit 1
+    fi
+done
+
+# Test 8: Clarity exceptions are present
+for phrase in 'Security warnings' 'Destructive or irreversible operations' 'Multi-step procedures' 'User confusion' 'Resume terse mode'; do
+    if grep -qiF "$phrase" "$SKILL_MD"; then
+        echo "[PASS] clarity exception present: $phrase"
+    else
+        echo "[FAIL] clarity exception missing: $phrase"; exit 1
+    fi
+done
+
+# Test 9: Neutral implementation, no caveman persona
+if grep -qiF 'caveman' "$SKILL_MD"; then
+    echo "[FAIL] skill mentions caveman"; exit 1
+else
+    echo "[PASS] skill is neutral"
+fi
+
+# Test 10: No literal U+2014 or U+2013 characters
+if grep -qP '[\x{2013}\x{2014}]' "$SKILL_MD"; then
+    echo "[FAIL] U+2014 or U+2013 in SKILL.md"; exit 1
+else
+    echo "[PASS] no U+2014 or U+2013"
+fi
+
+echo "=== Tests complete ==="


### PR DESCRIPTION
## Summary

- Add a Workbench `terse-mode` skill for explicit token-saving session style switches.
- Document activation, persistence, disable phrases, non-trigger brevity requests, and clarity exceptions.
- Add deterministic unit coverage plus positive and negative skill-trigger fixtures.

## Impact

Users can opt into compact replies with explicit phrases such as `terse mode` or `token saving mode`, then return to normal responses with disable phrases such as `normal mode`. Ordinary editing requests like making prose concise do not switch the session style.

## Validation

- `bash tests/unit/test-workbench-terse-mode-skill.sh`
- `bash tests/unit/test-workbench-brainstorming-skill.sh`
- `bash tests/unit/test-workbench-writing-spec-skill.sh`
- `bash tests/unit/test-workbench-visualizing-options-skill.sh`
- `bash tests/unit/test-workbench-autopilot-skill.sh`
- `bash tests/unit/test-codex-plugin-structure.sh`
- `PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh --not terse-mode tests/skill-triggering/prompts/workbench-terse-mode-no-trigger-concise.txt`
- `PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh terse-mode tests/skill-triggering/prompts/workbench-terse-mode.txt`
- `PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh terse-mode tests/skill-triggering/prompts/workbench-terse-mode-slug.txt`
- `PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh terse-mode tests/skill-triggering/prompts/workbench-token-saving-mode.txt`
