### PR TITLE
feat(workbench): port test-driven-development skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "workbench",
       "source": "./plugins/workbench",
       "description": "Personal Workbench skills for design and autonomous feature work.",
-      "version": "0.7.1"
+      "version": "0.8.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ tests/
 | `writing` | 1.6.1 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.3.0 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
-| `workbench` | 0.7.1 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion` |
+| `workbench` | 0.8.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development` |
 
 ## How to Develop a New Skill
 
@@ -193,6 +193,7 @@ Add the new plugin/skill to the Plugins section, Installation commands, and Setu
 ```bash
 # Unit tests (no auth required)
 PLUGIN_DIR=plugins/<plugin> bash tests/unit/test-<service>-skill.sh
+bash tests/unit/test-skill-frontmatter-yaml.sh
 
 # Codex plugin structure
 bash tests/unit/test-codex-plugin-structure.sh
@@ -208,7 +209,7 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh --not <skill
 ## Design Decisions
 
 - **No wrapper scripts.** Skills use the underlying CLI directly (`gws` for Google Workspace) or raw `curl` with env-var auth (for Atlassian). This keeps each skill self-contained — no extra bash layer to maintain, debug, or ship with the plugin.
-- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
+- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
 - **Every plugin change bumps version.** Any change to a plugin's skills, metadata, docs, hooks, agents, or tests must bump that plugin's version in lockstep across both runtime manifests and every marketplace entry that records a version. New skills are minor bumps; fixes, docs, tests, and description changes are patch bumps unless they change behavior materially.
 - **Skills are self-contained.** Each SKILL.md should contain everything the host agent needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Codex compatibility is metadata plus platform mapping.** Codex manifests live beside Claude Code manifests and point at the same `skills` directory. Platform-specific tool differences belong in the shared skill body as a mapping, not in duplicated skill files.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `visualizing-options` | workbench | Browser-based visual companion for layout choices |
 | `using-workbench` | workbench | Load Workbench skill rules and routing |
 | `terse-mode` | workbench | Explicit session switch for compact token-saving replies |
+| `autopilot` | workbench | Ship a feature from brainstorm to PR using a project profile |
+| `verification-before-completion` | workbench | Require fresh verification evidence before completion claims |
+| `writing-plans` | workbench | Turn approved specs into concrete implementation plans |
+| `test-driven-development` | workbench | Enforce test-first RED-GREEN-REFACTOR implementation discipline |
 | `creating-skills` | agent-system-management | Scaffold, iterate, pressure-test, and tune skills across the full lifecycle |
 
 ## Plugins
@@ -82,11 +86,14 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 
 **Skills:**
 - `/pgoell-claude-tools:brainstorming`: Sequential question-and-answer loop to clarify design intent. Hands off to `writing-spec` when the design is ready to be written down.
-- `/pgoell-claude-tools:writing-spec`: Synthesize a design discussion into a spec doc, run a fresh-eyes self-review subagent, gate on user approval, then hand off to `superpowers:writing-plans`.
+- `/pgoell-claude-tools:writing-spec`: Synthesize a design discussion into a spec doc, run a fresh-eyes self-review subagent, gate on user approval, then hand off to `workbench:writing-plans`.
 - `/pgoell-claude-tools:visualizing-options`: Browser-based visual companion for mockups, layout comparisons, wireframes, and architecture diagrams. The user clicks to choose between options.
 - `/pgoell-claude-tools:using-workbench`: Load Workbench skill rules and routing.
 - `/pgoell-claude-tools:terse-mode`: Explicit session switch for compact token-saving replies until disabled with normal mode.
 - `/pgoell-claude-tools:autopilot`: Ship a feature from brainstorm to PR using a project profile.
+- `/pgoell-claude-tools:verification-before-completion`: Require fresh verification evidence before completion claims.
+- `/pgoell-claude-tools:writing-plans`: Turn approved specs into concrete implementation plans.
+- `/pgoell-claude-tools:test-driven-development`: Enforce test-first RED-GREEN-REFACTOR implementation discipline.
 
 Autopilot profiles are documented in `plugins/workbench/skills/autopilot/references/profile-schema.md`.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/NOTICE
+++ b/plugins/workbench/NOTICE
@@ -20,6 +20,7 @@ Files derived from upstream Superpowers:
   skills/using-workbench/references/using-superpowers-upstream.md
   skills/verification-before-completion/SKILL.md
   skills/writing-plans/SKILL.md
+  skills/test-driven-development/SKILL.md
   hooks/hooks.json
   hooks/run-hook.cmd
   hooks/session-start

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -10,6 +10,7 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 - `autopilot`: Ship a feature from brainstorm to PR using a project profile.
 - `verification-before-completion`: Require fresh verification evidence before completion claims.
 - `writing-plans`: Turn approved specs into concrete implementation plans.
+- `test-driven-development`: Enforce test-first RED-GREEN-REFACTOR implementation discipline.
 
 ## Project profiles
 

--- a/plugins/workbench/skills/autopilot/SKILL.md
+++ b/plugins/workbench/skills/autopilot/SKILL.md
@@ -46,7 +46,7 @@ Read `references/required-skills.md` for the full table and `replaces` / `additi
 | 2 | `workbench:brainstorming` |
 | 3 | `workbench:writing-spec` |
 | 4 | `workbench:writing-plans` |
-| 5 | `superpowers:test-driven-development` and `superpowers:subagent-driven-development` |
+| 5 | `workbench:test-driven-development` and `superpowers:subagent-driven-development` |
 | 6 | `agent-system-management:capturing-session-learnings` and `agent-system-management:improving-instructions` |
 | pre-PR | `workbench:verification-before-completion` |
 
@@ -135,7 +135,7 @@ If `Hooks.post_plan` is defined, run it now with `{{plan_path}}` substituted.
 
 ### Step 5: Execute the plan
 
-**First actions, in order:** invoke `superpowers:test-driven-development`, then `superpowers:subagent-driven-development`. Both via the `Skill` tool. (Replace either if the profile says so.) TDD governs every implementation chunk; subagent-driven-development governs how those chunks run.
+**First actions, in order:** invoke `workbench:test-driven-development`, then `superpowers:subagent-driven-development`. Both via the `Skill` tool. (Replace either if the profile says so.) TDD governs every implementation chunk; subagent-driven-development governs how those chunks run.
 
 **Subagent dispatch (Claude Code):** see `references/claude-code-adapter.md` for the full pattern. Summary:
 

--- a/plugins/workbench/skills/autopilot/references/required-skills.md
+++ b/plugins/workbench/skills/autopilot/references/required-skills.md
@@ -10,7 +10,7 @@ The universal table that the autopilot skill walks at the pre-PR audit. Profiles
 | 2 | `workbench:brainstorming` | already ported into workbench |
 | 3 | `workbench:writing-spec` | already ported into workbench |
 | 4 | `workbench:writing-plans` | already ported into workbench |
-| 5 | `superpowers:test-driven-development` | not yet ported |
+| 5 | `workbench:test-driven-development` | ported into workbench |
 | 5 | `superpowers:subagent-driven-development` | not yet ported |
 | 6 | `agent-system-management:capturing-session-learnings` | cross-plugin |
 | 6 | `agent-system-management:improving-instructions` | cross-plugin |

--- a/plugins/workbench/skills/test-driven-development/SKILL.md
+++ b/plugins/workbench/skills/test-driven-development/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: test-driven-development
+description: "Use when implementing any feature, bugfix, refactor, or behavior change before writing implementation code. Enforces test-first RED-GREEN-REFACTOR discipline."
+---
+
+# Test-Driven Development
+
+Use this skill before implementation work. It governs each small implementation chunk until the change is complete.
+
+## Core Rule
+
+Write the test first. Watch it fail for the expected reason. Write the smallest code that makes it pass. Refactor only after green.
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+If implementation code was written before the test, delete that implementation and restart from the test. Do not keep it as reference material.
+
+## When To Use
+
+Use for:
+
+- New features.
+- Bug fixes.
+- Refactoring that can change behavior.
+- Any user-visible behavior change.
+
+Exceptions require an explicit user decision:
+
+- Throwaway prototypes.
+- Generated code.
+- Pure configuration changes.
+
+## Red-Green-Refactor
+
+### RED: Write One Failing Test
+
+Write the smallest test that expresses one expected behavior.
+
+Requirements:
+
+- One behavior per test.
+- Clear name that describes the expected behavior.
+- Real code when possible. Use mocks only when the boundary is external or expensive.
+- No broad "works" tests.
+
+### Verify RED
+
+Run the narrowest useful test command.
+
+Confirm:
+
+- The test fails.
+- The failure is the expected assertion or missing behavior.
+- The failure is not a syntax error, setup error, typo, or unrelated broken test.
+
+If the test passes immediately, it does not prove the new behavior. Fix the test before writing implementation code.
+
+### GREEN: Write Minimal Code
+
+Write only the implementation needed for the failing test.
+
+Do not add:
+
+- Extra options.
+- Future-proofing.
+- Unrequested error handling.
+- Refactors that are not needed for the current test.
+
+### Verify GREEN
+
+Run the narrow test again and confirm it passes. Then run the relevant broader test command for the touched area.
+
+If the test fails, fix implementation code first. Only change the test if the expected behavior is wrong.
+
+### REFACTOR
+
+After green only:
+
+- Improve names.
+- Remove duplication.
+- Move code into existing local patterns.
+
+Keep the same tests green after every refactor.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---|---|---|
+| Minimal | One behavior. | A test name with "and" covering multiple behaviors. |
+| Clear | Name states the expected behavior. | `test1` or `works`. |
+| Behavior-focused | Exercises public behavior. | Checks private implementation details. |
+| Repeatable | Runs without manual state. | Depends on local setup not created by the test. |
+
+## Common Rationalizations
+
+| Excuse | Response |
+|---|---|
+| "Too simple to test." | Simple code still breaks. Write the small test. |
+| "I'll test after." | Tests written after implementation can pass without proving they catch the missing behavior. |
+| "I already manually tested it." | Manual checks are not repeatable regression coverage. |
+| "The existing code has no tests." | Add the narrowest test around the behavior you are changing. |
+| "Keeping the code as reference is harmless." | Reference code biases the test. Delete it and restart test-first. |
+| "TDD is slowing me down." | Debugging untested behavior is usually slower than proving it incrementally. |
+
+## Red Flags
+
+Stop and restart the chunk if any of these happen:
+
+- Implementation code before a failing test.
+- Test added after implementation.
+- Test passes immediately.
+- You cannot explain the failure.
+- The failure is from setup or syntax instead of missing behavior.
+- You are rationalizing "just this once."
+- You are adapting code that was written before the test.
+
+## Workflow With Plans
+
+When executing a Workbench implementation plan, this skill is invoked as `workbench:test-driven-development`:
+
+1. Take one checkbox implementation chunk.
+2. Write or update the test first.
+3. Run the exact command and capture the expected failure.
+4. Implement the smallest passing change.
+5. Run the exact command and relevant broader checks.
+6. Mark the chunk complete only after green.
+
+If a chunk is too large to test first, split the chunk. Hard-to-test behavior is usually underspecified or poorly isolated.
+
+## Runtime Notes
+
+Use the test runner documented by the project. In this repository, prefer deterministic filesystem checks for skill structure and run the frontmatter lint after changing any `SKILL.md`.

--- a/plugins/workbench/skills/using-workbench/SKILL.md
+++ b/plugins/workbench/skills/using-workbench/SKILL.md
@@ -117,6 +117,6 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 Workbench coexists with the upstream `superpowers` plugin. If both are installed, both meta-skills (`using-workbench` and `using-superpowers`) may fire at session start. Their content overlaps but workbench's version is authoritative for workbench skills.
 
-When a slug exists in both workbench and superpowers (today: `brainstorming`), prefer the workbench version. The host agent should resolve the bare slug `brainstorming` to `workbench:brainstorming`.
+When a slug exists in both workbench and superpowers, prefer the workbench version. Today that includes `brainstorming` and `test-driven-development`. The host agent should resolve bare slugs such as `brainstorming` and `test-driven-development` to `workbench:brainstorming` and `workbench:test-driven-development`.
 
 For attribution and a frozen snapshot of upstream `using-superpowers/SKILL.md` at v5.0.7, see `references/using-superpowers-upstream.md`. Workbench-specific divergences from that snapshot are documented in this file's git history; the snapshot itself is intentionally not edited.

--- a/plugins/workbench/skills/writing-plans/SKILL.md
+++ b/plugins/workbench/skills/writing-plans/SKILL.md
@@ -60,7 +60,7 @@ Every plan MUST start with this header:
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:test-driven-development` for implementation chunks. Use `superpowers:subagent-driven-development` when independent tasks can be delegated, or execute sequentially in the main session when subagents are unavailable. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `workbench:test-driven-development` for implementation chunks. Use `superpowers:subagent-driven-development` when independent tasks can be delegated, or execute sequentially in the main session when subagents are unavailable. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -148,7 +148,7 @@ After saving the plan, report the path and offer the execution route that fits t
 ```text
 Plan complete and saved to `<path>`.
 
-Recommended execution: use `superpowers:test-driven-development` for each implementation chunk. If subagents are available, use `superpowers:subagent-driven-development`; otherwise execute the checkbox steps sequentially in this session.
+Recommended execution: use `workbench:test-driven-development` for each implementation chunk. If subagents are available, use `superpowers:subagent-driven-development`; otherwise execute the checkbox steps sequentially in this session.
 ```
 
 Do not start implementation until the plan is saved, the reviewer pass is complete, and the required implementation discipline is clear.

--- a/tests/skill-triggering/prompts/test-driven-development-bugfix.txt
+++ b/tests/skill-triggering/prompts/test-driven-development-bugfix.txt
@@ -1,0 +1,1 @@
+Fix the empty email validation bug with test-driven development.

--- a/tests/skill-triggering/prompts/test-driven-development-feature.txt
+++ b/tests/skill-triggering/prompts/test-driven-development-feature.txt
@@ -1,0 +1,1 @@
+Implement a new retry helper. Use TDD and show me the failing test before the implementation.

--- a/tests/unit/test-workbench-autopilot-skill.sh
+++ b/tests/unit/test-workbench-autopilot-skill.sh
@@ -67,7 +67,7 @@ echo ""
 
 # Test 5: SKILL.md mentions every skill in the universal table
 echo "Test 5: SKILL.md mentions every universal skill..."
-for skill in 'workbench:using-workbench' 'workbench:brainstorming' 'workbench:writing-spec' 'workbench:writing-plans' 'superpowers:test-driven-development' 'superpowers:subagent-driven-development' 'agent-system-management:capturing-session-learnings' 'agent-system-management:improving-instructions' 'workbench:verification-before-completion'; do
+for skill in 'workbench:using-workbench' 'workbench:brainstorming' 'workbench:writing-spec' 'workbench:writing-plans' 'workbench:test-driven-development' 'superpowers:subagent-driven-development' 'agent-system-management:capturing-session-learnings' 'agent-system-management:improving-instructions' 'workbench:verification-before-completion'; do
     if grep -qF "$skill" "$SKILL_MD"; then
         echo "  [PASS] SKILL.md mentions $skill"
     else
@@ -157,25 +157,25 @@ else
 fi
 echo ""
 
-# Test 11: Plugin manifests at 0.7.1
-echo "Test 11: Plugin manifests at 0.7.1..."
+# Test 11: Plugin manifests at 0.8.0
+echo "Test 11: Plugin manifests at 0.8.0..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.7.1"' "$CCM" >/dev/null && jq -e '.version == "0.7.1"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.7.1"
+if jq -e '.version == "0.8.0"' "$CCM" >/dev/null && jq -e '.version == "0.8.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.8.0"
 else
-    echo "  [FAIL] plugin manifests not at 0.7.1"
+    echo "  [FAIL] plugin manifests not at 0.8.0"
     exit 1
 fi
 echo ""
 
-# Test 12: Marketplace entries at 0.7.1
+# Test 12: Marketplace entries at 0.8.0
 echo "Test 12: Marketplace entries..."
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.7.1"' "$MP" >/dev/null; then
-    echo "  [PASS] Claude marketplace workbench at 0.7.1"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.8.0"' "$MP" >/dev/null; then
+    echo "  [PASS] Claude marketplace workbench at 0.8.0"
 else
-    echo "  [FAIL] Claude marketplace workbench not at 0.7.1"
+    echo "  [FAIL] Claude marketplace workbench not at 0.8.0"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-workbench-test-driven-development-skill.sh
+++ b/tests/unit/test-workbench-test-driven-development-skill.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Test: workbench:test-driven-development skill structure
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/test-driven-development"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+echo "=== Test: workbench:test-driven-development skill ==="
+
+if [ -s "$SKILL_MD" ] && head -1 "$SKILL_MD" | grep -q '^---$'; then
+    echo "[PASS] SKILL.md exists with frontmatter"
+else
+    echo "[FAIL] SKILL.md missing or no frontmatter"; exit 1
+fi
+
+for marker in \
+    'NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST' \
+    'Red-Green-Refactor' \
+    'Verify RED' \
+    'Verify GREEN' \
+    'Common Rationalizations' \
+    'workbench'; do
+    if grep -qF "$marker" "$SKILL_MD"; then
+        echo "[PASS] body mentions $marker"
+    else
+        echo "[FAIL] body missing $marker"; exit 1
+    fi
+done
+
+if grep -qP '[\x{2013}\x{2014}]' "$SKILL_MD"; then
+    echo "[FAIL] em-dash or en-dash in SKILL.md"; exit 1
+else
+    echo "[PASS] no em or en-dash"
+fi
+
+if grep -qF 'test-driven-development' "$REPO_ROOT/plugins/workbench/README.md"; then
+    echo "[PASS] README lists test-driven-development"
+else
+    echo "[FAIL] README missing test-driven-development"; exit 1
+fi
+
+if grep -qF 'skills/test-driven-development/SKILL.md' "$REPO_ROOT/plugins/workbench/NOTICE"; then
+    echo "[PASS] NOTICE credits test-driven-development"
+else
+    echo "[FAIL] NOTICE missing test-driven-development"; exit 1
+fi
+
+USING="$REPO_ROOT/plugins/workbench/skills/using-workbench/SKILL.md"
+if grep -qF 'workbench:test-driven-development' "$USING"; then
+    echo "[PASS] using-workbench routes bare test-driven-development to workbench"
+else
+    echo "[FAIL] using-workbench missing test-driven-development routing"; exit 1
+fi
+
+AUTO="$REPO_ROOT/plugins/workbench/skills/autopilot/SKILL.md"
+RS="$REPO_ROOT/plugins/workbench/skills/autopilot/references/required-skills.md"
+for f in "$AUTO" "$RS"; do
+    if grep -qF 'workbench:test-driven-development' "$f"; then
+        echo "[PASS] $(basename "$f") mentions workbench:test-driven-development"
+    else
+        echo "[FAIL] $(basename "$f") missing workbench:test-driven-development"; exit 1
+    fi
+done
+
+CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
+CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
+if jq -e '.version == "0.8.0"' "$CCM" >/dev/null && jq -e '.version == "0.8.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.8.0"
+else
+    echo "[FAIL] plugin manifests not at 0.8.0"; exit 1
+fi
+
+MP="$REPO_ROOT/.claude-plugin/marketplace.json"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.8.0"' "$MP" >/dev/null; then
+    echo "[PASS] Claude marketplace workbench at 0.8.0"
+else
+    echo "[FAIL] Claude marketplace workbench not at 0.8.0"; exit 1
+fi
+
+echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-writing-plans-skill.sh
+++ b/tests/unit/test-workbench-writing-plans-skill.sh
@@ -25,7 +25,7 @@ for marker in 'Path Resolution' 'Scope Check' 'File Structure' 'Bite-Sized Task 
     fi
 done
 
-for marker in 'workbench:writing-spec' 'checkbox (`- [ ]`) syntax' 'exact file paths' 'Expected: FAIL' 'Expected: PASS' 'git commit -m'; do
+for marker in 'workbench:writing-spec' 'workbench:test-driven-development' 'checkbox (`- [ ]`) syntax' 'exact file paths' 'Expected: FAIL' 'Expected: PASS' 'git commit -m'; do
     if grep -qF "$marker" "$SKILL_MD"; then
         echo "[PASS] planning rule mentions $marker"
     else


### PR DESCRIPTION
## Summary
- Add `workbench:test-driven-development` as a strict RED-GREEN-REFACTOR workflow skill.
- Switch Workbench autopilot and writing plans to use the Workbench TDD skill.
- Bump Workbench to `0.8.0` and update docs, NOTICE, prompt fixtures, and unit tests.

## Test plan
- [x] `bash tests/unit/test-workbench-test-driven-development-skill.sh`
- [x] `bash tests/unit/test-workbench-autopilot-skill.sh`
- [x] `bash tests/unit/test-workbench-writing-plans-skill.sh`
- [x] `bash tests/unit/test-codex-plugin-structure.sh`
- [x] `bash tests/unit/test-skill-frontmatter-yaml.sh`
- [x] `git diff --check`

Spec: `/tmp/pgoell-claude-tools-autopilot/2026-05-07-workbench-tdd-design.md`
Plan: `/tmp/pgoell-claude-tools-autopilot/2026-05-07-workbench-tdd.md`