### PR TITLE
feat(workbench): port subagent workflow skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "workbench",
       "source": "./plugins/workbench",
       "description": "Personal Workbench skills for design and autonomous feature work.",
-      "version": "0.8.0"
+      "version": "0.9.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ tests/
 | `writing` | 1.6.1 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.3.0 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
-| `workbench` | 0.8.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development` |
+| `workbench` | 0.9.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development` |
 
 ## How to Develop a New Skill
 
@@ -209,7 +209,7 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh --not <skill
 ## Design Decisions
 
 - **No wrapper scripts.** Skills use the underlying CLI directly (`gws` for Google Workspace) or raw `curl` with env-var auth (for Atlassian). This keeps each skill self-contained — no extra bash layer to maintain, debug, or ship with the plugin.
-- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
+- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
 - **Every plugin change bumps version.** Any change to a plugin's skills, metadata, docs, hooks, agents, or tests must bump that plugin's version in lockstep across both runtime manifests and every marketplace entry that records a version. New skills are minor bumps; fixes, docs, tests, and description changes are patch bumps unless they change behavior materially.
 - **Skills are self-contained.** Each SKILL.md should contain everything the host agent needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Codex compatibility is metadata plus platform mapping.** Codex manifests live beside Claude Code manifests and point at the same `skills` directory. Platform-specific tool differences belong in the shared skill body as a mapping, not in duplicated skill files.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `verification-before-completion` | workbench | Require fresh verification evidence before completion claims |
 | `writing-plans` | workbench | Turn approved specs into concrete implementation plans |
 | `test-driven-development` | workbench | Enforce test-first RED-GREEN-REFACTOR implementation discipline |
+| `dispatching-parallel-agents` | workbench | Split independent tasks across concurrent agents |
+| `subagent-driven-development` | workbench | Execute implementation plans with fresh agents and review gates |
 | `creating-skills` | agent-system-management | Scaffold, iterate, pressure-test, and tune skills across the full lifecycle |
 
 ## Plugins
@@ -94,6 +96,8 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 - `/pgoell-claude-tools:verification-before-completion`: Require fresh verification evidence before completion claims.
 - `/pgoell-claude-tools:writing-plans`: Turn approved specs into concrete implementation plans.
 - `/pgoell-claude-tools:test-driven-development`: Enforce test-first RED-GREEN-REFACTOR implementation discipline.
+- `/pgoell-claude-tools:dispatching-parallel-agents`: Split independent tasks across concurrent agents.
+- `/pgoell-claude-tools:subagent-driven-development`: Execute implementation plans with fresh agents and review gates.
 
 Autopilot profiles are documented in `plugins/workbench/skills/autopilot/references/profile-schema.md`.
 

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/NOTICE
+++ b/plugins/workbench/NOTICE
@@ -21,6 +21,8 @@ Files derived from upstream Superpowers:
   skills/verification-before-completion/SKILL.md
   skills/writing-plans/SKILL.md
   skills/test-driven-development/SKILL.md
+  skills/dispatching-parallel-agents/SKILL.md
+  skills/subagent-driven-development/SKILL.md
   hooks/hooks.json
   hooks/run-hook.cmd
   hooks/session-start

--- a/plugins/workbench/README.md
+++ b/plugins/workbench/README.md
@@ -11,6 +11,8 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 - `verification-before-completion`: Require fresh verification evidence before completion claims.
 - `writing-plans`: Turn approved specs into concrete implementation plans.
 - `test-driven-development`: Enforce test-first RED-GREEN-REFACTOR implementation discipline.
+- `dispatching-parallel-agents`: Split independent tasks across concurrent agents.
+- `subagent-driven-development`: Execute implementation plans with fresh agents and review gates.
 
 ## Project profiles
 

--- a/plugins/workbench/skills/autopilot/SKILL.md
+++ b/plugins/workbench/skills/autopilot/SKILL.md
@@ -46,7 +46,7 @@ Read `references/required-skills.md` for the full table and `replaces` / `additi
 | 2 | `workbench:brainstorming` |
 | 3 | `workbench:writing-spec` |
 | 4 | `workbench:writing-plans` |
-| 5 | `workbench:test-driven-development` and `superpowers:subagent-driven-development` |
+| 5 | `workbench:test-driven-development`, `workbench:dispatching-parallel-agents`, and `workbench:subagent-driven-development` |
 | 6 | `agent-system-management:capturing-session-learnings` and `agent-system-management:improving-instructions` |
 | pre-PR | `workbench:verification-before-completion` |
 
@@ -54,7 +54,7 @@ If a listed skill is unavailable in the current runtime, say so explicitly in th
 
 ## Runtime adapters
 
-This skill uses Claude Code tool names by default. If running on Codex, see `references/codex-adapter.md` for the tool-name mapping and the sequential-fallback note for subagent-driven-development. For Claude Code specifics (subagent dispatch patterns, CI polling shape, error recovery), see `references/claude-code-adapter.md`.
+This skill uses Claude Code tool names by default. If running on Codex, see `references/codex-adapter.md` for the tool-name mapping and the sequential fallback note for subagent-driven-development. For Claude Code specifics (subagent dispatch patterns, CI polling shape, error recovery), see `references/claude-code-adapter.md`.
 
 ---
 
@@ -135,7 +135,7 @@ If `Hooks.post_plan` is defined, run it now with `{{plan_path}}` substituted.
 
 ### Step 5: Execute the plan
 
-**First actions, in order:** invoke `workbench:test-driven-development`, then `superpowers:subagent-driven-development`. Both via the `Skill` tool. (Replace either if the profile says so.) TDD governs every implementation chunk; subagent-driven-development governs how those chunks run.
+**First actions, in order:** invoke `workbench:test-driven-development`, then `workbench:dispatching-parallel-agents`, then `workbench:subagent-driven-development`. All three via the `Skill` tool. (Replace any of them if the profile says so.) TDD governs every implementation chunk, dispatching-parallel-agents governs safe fanout, and subagent-driven-development governs how chunks run.
 
 **Subagent dispatch (Claude Code):** see `references/claude-code-adapter.md` for the full pattern. Summary:
 

--- a/plugins/workbench/skills/autopilot/references/claude-code-adapter.md
+++ b/plugins/workbench/skills/autopilot/references/claude-code-adapter.md
@@ -19,7 +19,7 @@ Plan tasks dispatch through `Agent` with `subagent_type=general-purpose`. Three 
 
 ### Independent tasks (parallel)
 
-No shared files, no ordering dependency. Send multiple `Agent` calls in a single message; they run in parallel.
+No shared files, no ordering dependency. Invoke `workbench:dispatching-parallel-agents`, then send multiple `Agent` calls in a single message; they run in parallel.
 
 Typical examples:
 

--- a/plugins/workbench/skills/autopilot/references/codex-adapter.md
+++ b/plugins/workbench/skills/autopilot/references/codex-adapter.md
@@ -14,7 +14,7 @@ This doc maps the autopilot skill's tool references to Codex equivalents. The au
 
 ## Subagent strategy on Codex
 
-`superpowers:subagent-driven-development` is best-effort on Codex. The autopilot expects a fresh subagent per plan task. If Codex's runtime exposes such a primitive, use it. If it does not, fall back to **sequential execution in the main session with explicit context-reset discipline**:
+`workbench:subagent-driven-development` is best-effort on Codex. The autopilot expects a fresh subagent per plan task. If Codex's runtime exposes such a primitive, use it. If it does not, fall back to **sequential execution in the main session with explicit context-reset discipline**:
 
 1. Treat each plan task as its own logical scope.
 2. Before starting a task, write a one-line context-reset note: `--- starting task <n>: <title> ---`. This is for legibility, not behavior.
@@ -22,7 +22,7 @@ This doc maps the autopilot skill's tool references to Codex equivalents. The au
 4. After completing a task, write a one-line note: `--- completed task <n> ---`.
 5. Continue with the next task.
 
-Sequential fallback gives up the parallelism of independent tasks but preserves the per-task discipline of subagent-driven-development.
+Sequential fallback gives up the fanout from `workbench:dispatching-parallel-agents` but preserves the per-task discipline of subagent-driven-development.
 
 ## CI polling shape (step 8)
 

--- a/plugins/workbench/skills/autopilot/references/required-skills.md
+++ b/plugins/workbench/skills/autopilot/references/required-skills.md
@@ -11,7 +11,8 @@ The universal table that the autopilot skill walks at the pre-PR audit. Profiles
 | 3 | `workbench:writing-spec` | already ported into workbench |
 | 4 | `workbench:writing-plans` | already ported into workbench |
 | 5 | `workbench:test-driven-development` | ported into workbench |
-| 5 | `superpowers:subagent-driven-development` | not yet ported |
+| 5 | `workbench:dispatching-parallel-agents` | governs safe fanout for independent tasks |
+| 5 | `workbench:subagent-driven-development` | governs plan execution with subagents |
 | 6 | `agent-system-management:capturing-session-learnings` | cross-plugin |
 | 6 | `agent-system-management:improving-instructions` | cross-plugin |
 | pre-PR | `workbench:verification-before-completion` | verify before push and PR readiness claims |

--- a/plugins/workbench/skills/dispatching-parallel-agents/SKILL.md
+++ b/plugins/workbench/skills/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: dispatching-parallel-agents
+description: Use when facing two or more independent tasks that can be worked on concurrently without shared state or sequential dependencies.
+---
+
+# Dispatching Parallel Agents
+
+Delegate independent problem domains to separate agents so they can run concurrently while the main session coordinates scope, integration, and verification.
+
+## When To Use
+
+Use this skill when all of these are true:
+
+- There are two or more independent failures, investigations, or edits.
+- Each task can be understood with its own focused context.
+- Each task has a disjoint write scope, or is read-only.
+- The result of one task is not needed before another can start.
+
+Common cases:
+
+- Different failing test files with different likely root causes.
+- Independent package or module updates.
+- Multiple read-only codebase surveys.
+- Separate documentation updates in unrelated directories.
+
+## Do not use when
+
+- Failures are likely symptoms of one shared root cause.
+- Tasks edit the same files, generated artifacts, shared schemas, lockfiles, or global configuration.
+- One task depends on another task's result.
+- You need a single coherent system diagnosis before splitting work.
+
+When in doubt, do one short local pass to classify the work before dispatching agents.
+
+## Process
+
+1. Identify independent domains. Name the task, files, and expected output for each domain.
+2. Confirm disjoint write scopes. If two tasks might touch the same file, run them sequentially or merge them into one task.
+3. Dispatch agents in parallel. Give each agent only the context it needs.
+4. Keep the main session as coordinator. Do not duplicate the delegated work locally.
+5. Review returned summaries and diffs.
+6. Run the combined verification command after integration.
+
+## Prompt Shape
+
+Each agent prompt should include:
+
+- The exact problem domain.
+- Files or directories the agent owns.
+- Files or directories it must not edit.
+- Relevant failure output or acceptance criteria.
+- Expected final report format.
+
+Example:
+
+```md
+Investigate and fix failures in tests/unit/test-calendar-skill.sh.
+
+Ownership: tests/unit/test-calendar-skill.sh and plugins/google-workspace/skills/calendar/SKILL.md.
+Do not edit Gmail, Jira, Confluence, or Workbench files.
+
+Return:
+- Root cause.
+- Files changed.
+- Verification command and result.
+```
+
+## Runtime Mapping
+
+Claude Code: dispatch multiple `Agent` calls in one message when scopes are independent.
+
+Codex: use `spawn_agent` for independent sidecar work, or execute sequentially when subagents are unavailable. For code edits, give each worker a disjoint write set and tell it not to revert other workers' edits.
+
+## Integration Checklist
+
+- Read every returned summary before committing.
+- Inspect `git status` and `git diff`.
+- Resolve conflicts in the main session.
+- Run the full relevant test set after all agent work lands.
+- If one agent's result changes another agent's assumptions, re-verify the affected task.

--- a/plugins/workbench/skills/subagent-driven-development/SKILL.md
+++ b/plugins/workbench/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: subagent-driven-development
+description: Use when executing an implementation plan with fresh subagents, task ownership, and review gates in the current session.
+---
+
+# Subagent-Driven Development
+
+Execute an implementation plan by giving each task a focused implementation agent, then running two review gates before moving on.
+
+Core rule: the main session coordinates. Agents implement or review bounded work. The main session integrates, verifies, and decides when to proceed.
+
+## When To Use
+
+Use this skill when:
+
+- An implementation plan already exists.
+- The plan has checkbox tasks or similarly bounded steps.
+- Tasks can be assigned with clear ownership.
+- The current runtime has subagent support, or the main session can follow the same task discipline sequentially.
+
+If there is no plan yet, use `workbench:writing-plans` first. If implementation is starting, use `workbench:test-driven-development` before writing production code.
+
+## Task Loop
+
+For each plan task:
+
+1. Paste the task text into the agent prompt.
+2. Define ownership: files, directories, or behavior the agent may change.
+3. Include acceptance criteria and verification commands.
+4. Tell the agent it is not alone in the codebase and must not revert edits made by others.
+5. Wait for the implementation agent to return.
+6. Run the spec compliance reviewer.
+7. Fix any spec gaps and re-review.
+8. Run the code quality reviewer.
+9. Fix any quality issues and re-review.
+10. Mark the task complete only after both review gates pass.
+
+## Two review gates
+
+Spec compliance reviewer:
+
+- Confirms the implementation matches the plan and spec.
+- Flags missing requested behavior.
+- Flags extra behavior that was not requested.
+
+Code quality reviewer:
+
+- Checks maintainability, local patterns, tests, error handling, and integration risk.
+- Focuses on bugs and regressions, not style preferences.
+- Approves only when important issues are resolved.
+
+Do not start the code quality reviewer until spec compliance passes.
+
+## Implementation agent prompt
+
+```md
+Implement this plan task:
+
+[paste one checkbox task]
+
+Ownership:
+- You may edit: [files or directories]
+- Do not edit: [files or directories]
+
+Context:
+- Relevant spec or plan excerpt.
+- Relevant prior commits or decisions.
+
+Rules:
+- Use workbench:test-driven-development.
+- You are not alone in the codebase. Do not revert edits made by others.
+- Keep the change minimal.
+
+Return:
+- Status: DONE, DONE_WITH_CONCERNS, NEEDS_CONTEXT, or BLOCKED.
+- Files changed.
+- Verification commands and results.
+- Concerns, if any.
+```
+
+## Handling Agent Status
+
+`DONE`: proceed to spec compliance review.
+
+`DONE_WITH_CONCERNS`: read the concerns. Fix in-scope correctness, lint, test, or scope concerns before review.
+
+`NEEDS_CONTEXT`: provide the missing context and continue with the same task.
+
+`BLOCKED`: change something before retrying. Provide missing context, split the task, use a more capable model, or stop if the plan is wrong.
+
+## Parallelism
+
+Default to one implementation task at a time. This keeps review gates simple and avoids shared-state conflicts.
+
+Use `workbench:dispatching-parallel-agents` only when tasks are truly independent and have disjoint write scopes. If tasks share files, generated outputs, schemas, lockfiles, or ordering dependencies, run them sequentially.
+
+Read-only review agents may run in parallel when they review different artifacts.
+
+## Runtime Mapping
+
+Claude Code: use `Agent` with a focused prompt for implementation and review agents.
+
+Codex: use `spawn_agent` for independent sidecar tasks when useful. For urgent blocking work, implement locally and preserve the same task loop. For delegated code edits, assign a disjoint write set and tell the worker not to revert others' changes.
+
+## Completion
+
+After all tasks pass both review gates:
+
+- Run the full relevant verification set.
+- Inspect `git status` and `git diff`.
+- Use `workbench:verification-before-completion` before claiming the branch is complete or ready.

--- a/plugins/workbench/skills/using-workbench/SKILL.md
+++ b/plugins/workbench/skills/using-workbench/SKILL.md
@@ -117,6 +117,6 @@ Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
 
 Workbench coexists with the upstream `superpowers` plugin. If both are installed, both meta-skills (`using-workbench` and `using-superpowers`) may fire at session start. Their content overlaps but workbench's version is authoritative for workbench skills.
 
-When a slug exists in both workbench and superpowers, prefer the workbench version. Today that includes `brainstorming` and `test-driven-development`. The host agent should resolve bare slugs such as `brainstorming` and `test-driven-development` to `workbench:brainstorming` and `workbench:test-driven-development`.
+When a slug exists in both workbench and superpowers, prefer the workbench version. Today that includes `brainstorming`, `test-driven-development`, `dispatching-parallel-agents`, and `subagent-driven-development`. The host agent should resolve bare slugs such as `brainstorming`, `test-driven-development`, `dispatching-parallel-agents`, and `subagent-driven-development` to `workbench:brainstorming`, `workbench:test-driven-development`, `workbench:dispatching-parallel-agents`, and `workbench:subagent-driven-development`.
 
 For attribution and a frozen snapshot of upstream `using-superpowers/SKILL.md` at v5.0.7, see `references/using-superpowers-upstream.md`. Workbench-specific divergences from that snapshot are documented in this file's git history; the snapshot itself is intentionally not edited.

--- a/plugins/workbench/skills/writing-plans/SKILL.md
+++ b/plugins/workbench/skills/writing-plans/SKILL.md
@@ -60,7 +60,7 @@ Every plan MUST start with this header:
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use `workbench:test-driven-development` for implementation chunks. Use `superpowers:subagent-driven-development` when independent tasks can be delegated, or execute sequentially in the main session when subagents are unavailable. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `workbench:test-driven-development` for implementation chunks. Use `workbench:dispatching-parallel-agents` when independent tasks can safely fan out. Use `workbench:subagent-driven-development` for delegated plan execution, or execute sequentially in the main session when subagents are unavailable. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -148,7 +148,7 @@ After saving the plan, report the path and offer the execution route that fits t
 ```text
 Plan complete and saved to `<path>`.
 
-Recommended execution: use `workbench:test-driven-development` for each implementation chunk. If subagents are available, use `superpowers:subagent-driven-development`; otherwise execute the checkbox steps sequentially in this session.
+Recommended execution: use `workbench:test-driven-development` for each implementation chunk. If subagents are available, use `workbench:subagent-driven-development`; otherwise execute the checkbox steps sequentially in this session. Use `workbench:dispatching-parallel-agents` only for independent tasks with disjoint write scopes.
 ```
 
 Do not start implementation until the plan is saved, the reviewer pass is complete, and the required implementation discipline is clear.

--- a/tests/skill-triggering/prompts/dispatching-parallel-agents-failures.txt
+++ b/tests/skill-triggering/prompts/dispatching-parallel-agents-failures.txt
@@ -1,0 +1,1 @@
+Three unrelated test files are failing. Use parallel agents to investigate each one independently.

--- a/tests/skill-triggering/prompts/subagent-driven-development-plan.txt
+++ b/tests/skill-triggering/prompts/subagent-driven-development-plan.txt
@@ -1,0 +1,1 @@
+Execute this implementation plan with a fresh subagent per task and review gates between tasks.

--- a/tests/unit/test-workbench-autopilot-skill.sh
+++ b/tests/unit/test-workbench-autopilot-skill.sh
@@ -67,7 +67,7 @@ echo ""
 
 # Test 5: SKILL.md mentions every skill in the universal table
 echo "Test 5: SKILL.md mentions every universal skill..."
-for skill in 'workbench:using-workbench' 'workbench:brainstorming' 'workbench:writing-spec' 'workbench:writing-plans' 'workbench:test-driven-development' 'superpowers:subagent-driven-development' 'agent-system-management:capturing-session-learnings' 'agent-system-management:improving-instructions' 'workbench:verification-before-completion'; do
+for skill in 'workbench:using-workbench' 'workbench:brainstorming' 'workbench:writing-spec' 'workbench:writing-plans' 'workbench:test-driven-development' 'workbench:dispatching-parallel-agents' 'workbench:subagent-driven-development' 'agent-system-management:capturing-session-learnings' 'agent-system-management:improving-instructions' 'workbench:verification-before-completion'; do
     if grep -qF "$skill" "$SKILL_MD"; then
         echo "  [PASS] SKILL.md mentions $skill"
     else
@@ -157,25 +157,25 @@ else
 fi
 echo ""
 
-# Test 11: Plugin manifests at 0.8.0
-echo "Test 11: Plugin manifests at 0.8.0..."
+# Test 11: Plugin manifests at 0.9.0
+echo "Test 11: Plugin manifests at 0.9.0..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.8.0"' "$CCM" >/dev/null && jq -e '.version == "0.8.0"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.8.0"
+if jq -e '.version == "0.9.0"' "$CCM" >/dev/null && jq -e '.version == "0.9.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.9.0"
 else
-    echo "  [FAIL] plugin manifests not at 0.8.0"
+    echo "  [FAIL] plugin manifests not at 0.9.0"
     exit 1
 fi
 echo ""
 
-# Test 12: Marketplace entries at 0.8.0
+# Test 12: Marketplace entries at 0.9.0
 echo "Test 12: Marketplace entries..."
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.8.0"' "$MP" >/dev/null; then
-    echo "  [PASS] Claude marketplace workbench at 0.8.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.9.0"' "$MP" >/dev/null; then
+    echo "  [PASS] Claude marketplace workbench at 0.9.0"
 else
-    echo "  [FAIL] Claude marketplace workbench not at 0.8.0"
+    echo "  [FAIL] Claude marketplace workbench not at 0.9.0"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-workbench-brainstorming-skill.sh
+++ b/tests/unit/test-workbench-brainstorming-skill.sh
@@ -59,13 +59,13 @@ else
     echo "[PASS] no em or en-dash"
 fi
 
-# Test 7: Plugin manifests at 0.7.0
+# Test 7: Plugin manifests at 0.9.0
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.7.0"' "$CCM" >/dev/null && jq -e '.version == "0.7.0"' "$CXM" >/dev/null; then
-    echo "[PASS] plugin manifests at 0.7.0"
+if jq -e '.version == "0.9.0"' "$CCM" >/dev/null && jq -e '.version == "0.9.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.9.0"
 else
-    echo "[FAIL] plugin manifests not at 0.7.0"; exit 1
+    echo "[FAIL] plugin manifests not at 0.9.0"; exit 1
 fi
 
 echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-dispatching-parallel-agents-skill.sh
+++ b/tests/unit/test-workbench-dispatching-parallel-agents-skill.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Test: workbench:dispatching-parallel-agents skill structure
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/dispatching-parallel-agents"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+echo "=== Test: workbench:dispatching-parallel-agents skill ==="
+
+if [ -s "$SKILL_MD" ] && head -1 "$SKILL_MD" | grep -q '^---$'; then
+    echo "[PASS] SKILL.md exists with frontmatter"
+else
+    echo "[FAIL] SKILL.md missing or no frontmatter"; exit 1
+fi
+
+for marker in \
+    'Dispatching Parallel Agents' \
+    'independent domains' \
+    'disjoint write scopes' \
+    'Do not use when' \
+    'Codex' \
+    'Claude Code'; do
+    if grep -qF "$marker" "$SKILL_MD"; then
+        echo "[PASS] body mentions $marker"
+    else
+        echo "[FAIL] body missing $marker"; exit 1
+    fi
+done
+
+if grep -qP '[\x{2013}\x{2014}]' "$SKILL_MD"; then
+    echo "[FAIL] em-dash or en-dash in SKILL.md"; exit 1
+else
+    echo "[PASS] no em or en-dash"
+fi
+
+for f in \
+    "$REPO_ROOT/plugins/workbench/README.md" \
+    "$REPO_ROOT/README.md" \
+    "$REPO_ROOT/plugins/workbench/NOTICE"; do
+    if grep -qF 'dispatching-parallel-agents' "$f"; then
+        echo "[PASS] $f mentions dispatching-parallel-agents"
+    else
+        echo "[FAIL] $f missing dispatching-parallel-agents"; exit 1
+    fi
+done
+
+USING="$REPO_ROOT/plugins/workbench/skills/using-workbench/SKILL.md"
+if grep -qF 'workbench:dispatching-parallel-agents' "$USING"; then
+    echo "[PASS] using-workbench routes dispatching-parallel-agents to workbench"
+else
+    echo "[FAIL] using-workbench missing dispatching-parallel-agents routing"; exit 1
+fi
+
+CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
+CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
+if jq -e '.version == "0.9.0"' "$CCM" >/dev/null && jq -e '.version == "0.9.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.9.0"
+else
+    echo "[FAIL] plugin manifests not at 0.9.0"; exit 1
+fi
+
+MP="$REPO_ROOT/.claude-plugin/marketplace.json"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.9.0"' "$MP" >/dev/null; then
+    echo "[PASS] Claude marketplace workbench at 0.9.0"
+else
+    echo "[FAIL] Claude marketplace workbench not at 0.9.0"; exit 1
+fi
+
+echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-subagent-driven-development-skill.sh
+++ b/tests/unit/test-workbench-subagent-driven-development-skill.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Test: workbench:test-driven-development skill structure
+# Test: workbench:subagent-driven-development skill structure
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../test-helpers.sh"
 
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/test-driven-development"
+SKILL_DIR="$REPO_ROOT/plugins/workbench/skills/subagent-driven-development"
 SKILL_MD="$SKILL_DIR/SKILL.md"
 
-echo "=== Test: workbench:test-driven-development skill ==="
+echo "=== Test: workbench:subagent-driven-development skill ==="
 
 if [ -s "$SKILL_MD" ] && head -1 "$SKILL_MD" | grep -q '^---$'; then
     echo "[PASS] SKILL.md exists with frontmatter"
@@ -18,12 +18,13 @@ else
 fi
 
 for marker in \
-    'NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST' \
-    'Red-Green-Refactor' \
-    'Verify RED' \
-    'Verify GREEN' \
-    'Common Rationalizations' \
-    'workbench'; do
+    'Subagent-Driven Development' \
+    'Two review gates' \
+    'Implementation agent prompt' \
+    'Spec compliance reviewer' \
+    'Code quality reviewer' \
+    'workbench:dispatching-parallel-agents' \
+    'workbench:test-driven-development'; do
     if grep -qF "$marker" "$SKILL_MD"; then
         echo "[PASS] body mentions $marker"
     else
@@ -37,32 +38,36 @@ else
     echo "[PASS] no em or en-dash"
 fi
 
-if grep -qF 'test-driven-development' "$REPO_ROOT/plugins/workbench/README.md"; then
-    echo "[PASS] README lists test-driven-development"
-else
-    echo "[FAIL] README missing test-driven-development"; exit 1
-fi
-
-if grep -qF 'skills/test-driven-development/SKILL.md' "$REPO_ROOT/plugins/workbench/NOTICE"; then
-    echo "[PASS] NOTICE credits test-driven-development"
-else
-    echo "[FAIL] NOTICE missing test-driven-development"; exit 1
-fi
+for f in \
+    "$REPO_ROOT/plugins/workbench/README.md" \
+    "$REPO_ROOT/README.md" \
+    "$REPO_ROOT/plugins/workbench/NOTICE"; do
+    if grep -qF 'subagent-driven-development' "$f"; then
+        echo "[PASS] $f mentions subagent-driven-development"
+    else
+        echo "[FAIL] $f missing subagent-driven-development"; exit 1
+    fi
+done
 
 USING="$REPO_ROOT/plugins/workbench/skills/using-workbench/SKILL.md"
-if grep -qF 'workbench:test-driven-development' "$USING"; then
-    echo "[PASS] using-workbench routes bare test-driven-development to workbench"
+if grep -qF 'workbench:subagent-driven-development' "$USING"; then
+    echo "[PASS] using-workbench routes subagent-driven-development to workbench"
 else
-    echo "[FAIL] using-workbench missing test-driven-development routing"; exit 1
+    echo "[FAIL] using-workbench missing subagent-driven-development routing"; exit 1
 fi
 
 AUTO="$REPO_ROOT/plugins/workbench/skills/autopilot/SKILL.md"
 RS="$REPO_ROOT/plugins/workbench/skills/autopilot/references/required-skills.md"
 for f in "$AUTO" "$RS"; do
-    if grep -qF 'workbench:test-driven-development' "$f"; then
-        echo "[PASS] $(basename "$f") mentions workbench:test-driven-development"
+    if grep -qF 'workbench:subagent-driven-development' "$f"; then
+        echo "[PASS] $(basename "$f") mentions workbench:subagent-driven-development"
     else
-        echo "[FAIL] $(basename "$f") missing workbench:test-driven-development"; exit 1
+        echo "[FAIL] $(basename "$f") missing workbench:subagent-driven-development"; exit 1
+    fi
+    if grep -qF 'superpowers:subagent-driven-development' "$f"; then
+        echo "[FAIL] $(basename "$f") still references superpowers:subagent-driven-development"; exit 1
+    else
+        echo "[PASS] $(basename "$f") does not reference superpowers:subagent-driven-development"
     fi
 done
 


### PR DESCRIPTION
## Summary
- Add workbench:dispatching-parallel-agents and workbench:subagent-driven-development.
- Update Workbench autopilot, writing-plans routing, docs, NOTICE, and version metadata to 0.9.0.
- Add deterministic unit tests and skill-triggering prompts for both skills.

## Test plan
- [x] bash tests/unit/test-workbench-dispatching-parallel-agents-skill.sh
- [x] bash tests/unit/test-workbench-subagent-driven-development-skill.sh
- [x] bash tests/unit/test-workbench-autopilot-skill.sh
- [x] bash tests/unit/test-skill-frontmatter-yaml.sh
- [x] bash tests/unit/test-codex-plugin-structure.sh
- [x] PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh dispatching-parallel-agents tests/skill-triggering/prompts/dispatching-parallel-agents-failures.txt
- [x] PLUGIN_DIR=plugins/workbench bash tests/skill-triggering/run-test.sh subagent-driven-development tests/skill-triggering/prompts/subagent-driven-development-plan.txt