### PR TITLE
[codex] add terminal tmux skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -115,6 +115,22 @@
         "displayName": "Workbench",
         "shortDescription": "Design and ship with Workbench skills"
       }
+    },
+    {
+      "name": "terminal",
+      "source": {
+        "source": "local",
+        "path": "./plugins/terminal"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools",
+      "interface": {
+        "displayName": "Terminal",
+        "shortDescription": "Control interactive CLIs through tmux"
+      }
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,6 +45,12 @@
       "source": "./plugins/workbench",
       "description": "Personal Workbench skills for design and autonomous feature work.",
       "version": "0.9.0"
+    },
+    {
+      "name": "terminal",
+      "source": "./plugins/terminal",
+      "description": "Control interactive terminal programs through tmux.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ tests/
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.3.0 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
 | `workbench` | 0.9.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development` |
+| `terminal` | 0.1.0 | `tmux` |
 
 ## How to Develop a New Skill
 
@@ -209,7 +210,7 @@ PLUGIN_DIR=plugins/<plugin> bash tests/skill-triggering/run-test.sh --not <skill
 ## Design Decisions
 
 - **No wrapper scripts.** Skills use the underlying CLI directly (`gws` for Google Workspace) or raw `curl` with env-var auth (for Atlassian). This keeps each skill self-contained — no extra bash layer to maintain, debug, or ship with the plugin.
-- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently.
+- **One skill per service, one plugin per product family.** Gmail and Calendar are both under `google-workspace`. Jira and Confluence are both under `atlassian`. Workbench is the exception: its skills (`brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`) are peer workflow and session-control capabilities rather than separate services, so they ship together but stay split so the host agent (or autopilot) can invoke each phase independently. Terminal capabilities that depend on local Unix tools belong in the `terminal` plugin so Windows users can skip them unless they use WSL.
 - **Every plugin change bumps version.** Any change to a plugin's skills, metadata, docs, hooks, agents, or tests must bump that plugin's version in lockstep across both runtime manifests and every marketplace entry that records a version. New skills are minor bumps; fixes, docs, tests, and description changes are patch bumps unless they change behavior materially.
 - **Skills are self-contained.** Each SKILL.md should contain everything the host agent needs to use the service without reading other files (except reference docs it explicitly links to).
 - **Codex compatibility is metadata plus platform mapping.** Codex manifests live beside Claude Code manifests and point at the same `skills` directory. Platform-specific tool differences belong in the shared skill body as a mapping, not in duplicated skill files.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The two runtimes use separate plugin metadata, but the skills are single sourced
 | `test-driven-development` | workbench | Enforce test-first RED-GREEN-REFACTOR implementation discipline |
 | `dispatching-parallel-agents` | workbench | Split independent tasks across concurrent agents |
 | `subagent-driven-development` | workbench | Execute implementation plans with fresh agents and review gates |
+| `tmux` | terminal | Control interactive terminal programs through isolated tmux sessions |
 | `creating-skills` | agent-system-management | Scaffold, iterate, pressure-test, and tune skills across the full lifecycle |
 
 ## Plugins
@@ -101,6 +102,13 @@ Workbench skills for design dialogue, skill routing, and profile driven feature 
 
 Autopilot profiles are documented in `plugins/workbench/skills/autopilot/references/profile-schema.md`.
 
+### terminal
+
+Terminal skills for interactive command-line programs.
+
+**Skills:**
+- `/pgoell-claude-tools:tmux`: Drive interactive CLIs, REPLs, debuggers, and experimental nested agent sessions through isolated tmux sessions.
+
 ## Installation
 
 ### Claude Code
@@ -114,6 +122,7 @@ Autopilot profiles are documented in `plugins/workbench/skills/autopilot/referen
 /plugin install runtime-bridge@pgoell-claude-tools
 /plugin install agent-system-management@pgoell-claude-tools
 /plugin install workbench@pgoell-claude-tools
+/plugin install terminal@pgoell-claude-tools
 ```
 
 ### Codex
@@ -131,7 +140,7 @@ codex
 /plugins
 ```
 
-In the picker, install `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`, `agent-system-management`, and `workbench`.
+In the picker, install `atlassian`, `google-workspace`, `research`, `writing`, `runtime-bridge`, `agent-system-management`, `workbench`, and `terminal`.
 
 `codex plugin marketplace add` accepts `owner/repo[@ref]`, an HTTPS or SSH Git URL, or a local marketplace root directory. The marketplace file lives at `.agents/plugins/marketplace.json` and the per-plugin Codex manifests live at `plugins/<plugin>/.codex-plugin/plugin.json`. Both reuse the same `plugins/<plugin>/skills/` directories as Claude Code, single sourced.
 
@@ -181,3 +190,7 @@ No setup required. In any project, ask the skill to align Claude Code and Codex 
 ### agent-system-management
 
 No setup required. Three skills in one plugin: ask `improving-instructions` to "audit my CLAUDE.md files" (cold audit), `capturing-session-learnings` to "update AGENTS.md with what we learned this session" (warm capture), or `creating-skills` to "scaffold a new skill in this marketplace", "iterate on this skill until it triggers reliably", "pressure-test this discipline skill", "optimize the description for triggering", or "turn this conversation into a reusable skill". The instruction skills operate on local agent-instruction files only (no network); the lifecycle skill detects the marketplace shape (Claude Code, Codex, or both) and adapts.
+
+### terminal
+
+Install `tmux` on Linux, macOS, or WSL. Native Windows terminals are not supported by the `tmux` skill.

--- a/plugins/terminal/.claude-plugin/plugin.json
+++ b/plugins/terminal/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "terminal",
+  "version": "0.1.0",
+  "description": "Control interactive terminal programs through tmux.",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "terminal",
+    "tmux",
+    "interactive",
+    "cli"
+  ]
+}

--- a/plugins/terminal/.codex-plugin/plugin.json
+++ b/plugins/terminal/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "terminal",
+  "version": "0.1.0",
+  "description": "Control interactive terminal programs through tmux.",
+  "author": {
+    "name": "Pascal Göllner"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "terminal",
+    "tmux",
+    "interactive",
+    "cli"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Terminal",
+    "shortDescription": "Control interactive CLIs through tmux",
+    "longDescription": "Use tmux sessions to drive interactive terminal programs, inspect pane output, and experiment with steering nested agent CLI sessions.",
+    "developerName": "Pascal Göllner",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use tmux to drive this interactive CLI",
+      "Start a Python REPL in tmux and inspect it",
+      "Try steering a Codex session through tmux"
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/terminal/LICENSE
+++ b/plugins/terminal/LICENSE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/plugins/terminal/NOTICE
+++ b/plugins/terminal/NOTICE
@@ -1,0 +1,13 @@
+Terminal
+
+This plugin includes content adapted from the upstream agent-stuff tmux skill by Armin Ronacher.
+
+Upstream: https://github.com/mitsuhiko/agent-stuff/tree/main/skills/tmux
+Upstream commit reviewed: a3f8ab1108a48fec9e175f6cd5d9aaa4694ce29d
+Upstream license: Apache-2.0
+
+Files adapted from upstream agent-stuff:
+
+  skills/tmux/SKILL.md
+
+Helper script behavior from upstream was converted into inline tmux command patterns instead of bundled scripts.

--- a/plugins/terminal/README.md
+++ b/plugins/terminal/README.md
@@ -1,0 +1,15 @@
+# Terminal
+
+Terminal skills for controlling interactive command-line programs.
+
+## Skills
+
+- `tmux`: Drive interactive CLIs through isolated tmux sessions.
+
+## Platform support
+
+The `tmux` skill requires `tmux` on Linux, macOS, or WSL. Native Windows terminals are not supported by this plugin.
+
+## Credits
+
+The `tmux` skill is adapted from Armin Ronacher's agent-stuff tmux skill.

--- a/plugins/terminal/skills/tmux/SKILL.md
+++ b/plugins/terminal/skills/tmux/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: tmux
+description: Use when the user wants to control interactive terminal programs through tmux, drive REPLs, debuggers, TUI tools, or experiment with steering nested Claude Code or Codex CLI sessions by sending keys and reading pane output.
+---
+
+# tmux Skill
+
+Use `tmux` as a programmable terminal for interactive CLIs that do not fit plain `exec` commands. This skill is for Linux, macOS, and WSL. Native Windows terminals are out of scope.
+
+---
+
+## Auth Approach
+
+No authentication is required. Attempt the `tmux` command first. If it fails, diagnose missing `tmux`, missing WSL, a dead socket, or a stale session.
+
+## Tool Preference
+
+Use the host shell tool to run `tmux` directly. Do not add helper scripts. Keep sessions on a private socket so agent-controlled panes stay separate from the user's personal tmux server.
+
+Platform mapping:
+
+- Claude Code: use the Bash tool for `tmux` commands.
+- Codex: use `exec_command` for `tmux` commands and `write_stdin` only for host PTY sessions, not tmux panes.
+
+## Session Convention
+
+Always create a socket directory and use `tmux -S "$SOCKET"`:
+
+```bash
+TMUX_SOCKET_DIR="${CLAUDE_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/agent-tmux-sockets}"
+mkdir -p "$TMUX_SOCKET_DIR"
+SOCKET="$TMUX_SOCKET_DIR/terminal.sock"
+SESSION="agent-python"
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
+```
+
+After starting a session, tell the user how to monitor it:
+
+```bash
+tmux -S "$SOCKET" attach -t "$SESSION"
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":. -S -200
+```
+
+Repeat the monitor command again when leaving a long-running session open.
+
+Use `"$SESSION":.` for the active pane unless you have inspected pane indexes. This avoids failures on user configs that start window indexes at `1`.
+
+## Operations: Tier 1 (Read)
+
+List sessions on the private socket:
+
+```bash
+tmux -S "$SOCKET" list-sessions
+```
+
+List panes with targets:
+
+```bash
+tmux -S "$SOCKET" list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_current_command} #{pane_title}'
+```
+
+Capture recent output from a pane:
+
+```bash
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":. -S -200
+```
+
+For full-screen TUIs where style escape codes matter during diagnosis, add `-e`:
+
+```bash
+tmux -S "$SOCKET" capture-pane -p -e -J -t "$SESSION":. -S -200
+```
+
+Scan all known agent sockets:
+
+```bash
+find "${CLAUDE_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/agent-tmux-sockets}" -type s -maxdepth 1 -print
+```
+
+## Operations: Tier 2 (Write)
+
+Start a new session:
+
+```bash
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n shell
+```
+
+Send literal text, then press Enter:
+
+```bash
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'python3 -q'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+Send control keys:
+
+```bash
+tmux -S "$SOCKET" send-keys -t "$SESSION":. C-c
+tmux -S "$SOCKET" send-keys -t "$SESSION":. C-d
+```
+
+Poll for prompt text without a helper script:
+
+```bash
+deadline=$((SECONDS + 15))
+while (( SECONDS < deadline )); do
+  pane="$(tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":. -S -200)"
+  printf '%s\n' "$pane" | grep -Eq '^>>>' && break
+  sleep 0.5
+done
+printf '%s\n' "$pane" | grep -Eq '^>>>'
+```
+
+## Operations: Tier 3 (Manage)
+
+Kill one session when the interactive task is done:
+
+```bash
+tmux -S "$SOCKET" kill-session -t "$SESSION"
+```
+
+Kill the private server only after confirming no useful sessions remain:
+
+```bash
+tmux -S "$SOCKET" kill-server
+```
+
+Ask before killing sessions that the user may be monitoring.
+
+## Recipes
+
+Python REPL:
+
+```bash
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'PYTHON_BASIC_REPL=1 python3 -q'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+Debugger:
+
+```bash
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'gdb --quiet ./a.out'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'set pagination off'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+Generic TTY program:
+
+```bash
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'psql "$DATABASE_URL"'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+## Steering Agent Sessions
+
+Use tmux for nested agent CLIs only as an experiment. It can work for observing and steering `codex` or `claude` sessions, but it is more brittle than native subagent tools because prompts, permission flows, and screen updates are text scraped from a terminal pane.
+
+Start a nested Codex session:
+
+```bash
+SESSION="agent-codex"
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n codex
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'codex'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+Start a nested Claude Code session:
+
+```bash
+SESSION="agent-claude"
+tmux -S "$SOCKET" new-session -d -s "$SESSION" -n claude
+tmux -S "$SOCKET" send-keys -t "$SESSION":. -l -- 'claude'
+tmux -S "$SOCKET" send-keys -t "$SESSION":. Enter
+```
+
+Rules for nested agents:
+
+- Keep each nested agent in its own session name and private socket.
+- Capture before sending input so you know what state the agent is in.
+- Wait several seconds before judging a blank pane. Agent CLIs may start MCP servers or render full-screen UI slowly.
+- Prefer plain text prompts and explicit commands.
+- Do not paste secrets into panes.
+- Expect manual intervention for auth, trust, model selection, plugin prompts, and permission prompts.
+- Prefer host-native subagent tools when the goal is normal delegation.
+
+## Self-Healing
+
+If `tmux` is missing, tell the user to install it. On Windows, recommend WSL with `tmux` installed inside the Linux environment.
+
+If a session is missing, run:
+
+```bash
+tmux -S "$SOCKET" list-sessions
+```
+
+If the pane target is wrong, run:
+
+```bash
+tmux -S "$SOCKET" list-panes -a
+```
+
+If a poll times out, capture the pane and reason from the visible state instead of blindly sending more input.
+
+## Behavioral Guidelines
+
+- Use tmux only for programs that require a persistent TTY.
+- Prefer simple shell commands for non-interactive work.
+- Use slug-like session names without spaces.
+- Always use `send-keys -l --` for literal text.
+- Use `capture-pane -p -J` before deciding the next keystroke.
+- Clean up finished sessions.
+- Leave monitor commands when a session remains open.

--- a/tests/skill-triggering/prompts/tmux-interactive-cli.txt
+++ b/tests/skill-triggering/prompts/tmux-interactive-cli.txt
@@ -1,0 +1,1 @@
+Use tmux to start a Python REPL, send it a couple of expressions, and show me the captured output.

--- a/tests/unit/test-codex-plugin-structure.sh
+++ b/tests/unit/test-codex-plugin-structure.sh
@@ -18,9 +18,9 @@ marketplace_name="$(jq -r '.name' "$MARKETPLACE")"
 [ "$marketplace_name" = "pgoell-claude-tools" ] || fail "Unexpected marketplace name: $marketplace_name"
 
 plugin_count="$(jq '.plugins | length' "$MARKETPLACE")"
-[ "$plugin_count" -eq 7 ] || fail "Expected 7 Codex marketplace plugins, got $plugin_count"
+[ "$plugin_count" -eq 8 ] || fail "Expected 8 Codex marketplace plugins, got $plugin_count"
 
-for plugin in atlassian google-workspace research writing runtime-bridge agent-system-management workbench; do
+for plugin in atlassian google-workspace research writing runtime-bridge agent-system-management workbench terminal; do
     plugin_dir="$REPO_ROOT/plugins/$plugin"
     manifest="$plugin_dir/.codex-plugin/plugin.json"
 

--- a/tests/unit/test-terminal-tmux-skill.sh
+++ b/tests/unit/test-terminal-tmux-skill.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Test: terminal:tmux skill structure
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/terminal/skills/tmux"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+echo "=== Test: terminal:tmux skill ==="
+
+if [ -s "$SKILL_MD" ] && head -1 "$SKILL_MD" | grep -q '^---$'; then
+    echo "[PASS] SKILL.md exists with frontmatter"
+else
+    echo "[FAIL] SKILL.md missing or no frontmatter"; exit 1
+fi
+
+for marker in \
+    'name: tmux' \
+    'interactive terminal programs' \
+    'tmux -S "$SOCKET"' \
+    'capture-pane -p -J' \
+    'send-keys -l --' \
+    'Steering Agent Sessions' \
+    'codex' \
+    'claude' \
+    'Native Windows terminals are out of scope' \
+    'Do not add helper scripts'; do
+    if grep -qF "$marker" "$SKILL_MD"; then
+        echo "[PASS] body mentions $marker"
+    else
+        echo "[FAIL] body missing $marker"; exit 1
+    fi
+done
+
+if find "$SKILL_DIR" -type f ! -name 'SKILL.md' | grep -q .; then
+    echo "[FAIL] tmux skill should not bundle helper scripts"; exit 1
+else
+    echo "[PASS] tmux skill has no helper scripts"
+fi
+
+if grep -qP '[\x{2013}\x{2014}]' "$SKILL_MD" "$REPO_ROOT/plugins/terminal/README.md" "$REPO_ROOT/plugins/terminal/NOTICE"; then
+    echo "[FAIL] U+2014 or U+2013 in terminal markdown"; exit 1
+else
+    echo "[PASS] no U+2014 or U+2013"
+fi
+
+for f in \
+    "$REPO_ROOT/plugins/terminal/README.md" \
+    "$REPO_ROOT/README.md" \
+    "$REPO_ROOT/AGENTS.md"; do
+    if grep -qF 'tmux' "$f"; then
+        echo "[PASS] $f mentions tmux"
+    else
+        echo "[FAIL] $f missing tmux"; exit 1
+    fi
+done
+
+for manifest in \
+    "$REPO_ROOT/plugins/terminal/.claude-plugin/plugin.json" \
+    "$REPO_ROOT/plugins/terminal/.codex-plugin/plugin.json"; do
+    if jq -e '.name == "terminal" and .version == "0.1.0" and .license == "Apache-2.0"' "$manifest" >/dev/null; then
+        echo "[PASS] $manifest metadata is valid"
+    else
+        echo "[FAIL] $manifest metadata invalid"; exit 1
+    fi
+done
+
+echo "=== Tests complete ==="


### PR DESCRIPTION
## Summary

Adds a new `terminal` plugin with a `tmux` skill for controlling interactive terminal programs through isolated tmux sessions.

The skill covers session setup, socket isolation, pane capture, literal key sends, cleanup, REPL and debugger recipes, and experimental steering of nested `codex` or `claude` CLI sessions. It keeps upstream helper behavior as inline command patterns instead of adding wrapper scripts.

## Validation

- `bash tests/unit/test-terminal-tmux-skill.sh`
- `bash tests/unit/test-skill-frontmatter-yaml.sh`
- `bash tests/unit/test-codex-plugin-structure.sh`
- Live tmux smoke test captured `tmux-smoke-ok` from a pane
