### PR TITLE
feat(workbench): track autopilot task progress

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "workbench",
       "source": "./plugins/workbench",
       "description": "Personal Workbench skills for design and autonomous feature work.",
-      "version": "0.9.0"
+      "version": "0.9.1"
     },
     {
       "name": "terminal",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ tests/
 | `writing` | 1.6.1 | `writing`, `pyramid`, `tech-doc` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.3.0 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
-| `workbench` | 0.9.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development` |
+| `workbench` | 0.9.1 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development` |
 | `terminal` | 0.1.0 | `tmux` |
 
 ## How to Develop a New Skill

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/skills/autopilot/SKILL.md
+++ b/plugins/workbench/skills/autopilot/SKILL.md
@@ -25,6 +25,19 @@ If the file exists:
 
 A field that no source provides and the active step needs stops the workflow with a question.
 
+## Task List Discipline
+
+Autopilot maintains a visible task list for the whole run and keeps it current. This is part of the workflow contract, not optional reporting.
+
+- Create the task list immediately after bootstrap and before step 0. Use one top-level item per autopilot step, plus one item for the skill audit.
+- Use the runtime's task-list primitive. Claude Code: `TodoWrite`. Codex: `update_plan`.
+- Keep exactly one item `in_progress` while work is active. Mark an item `completed` as soon as its step finishes.
+- Expand the task list dynamically when new work becomes known. After step 4 writes the implementation plan, add each implementation checkbox as a task-list item nested by naming convention, for example `Step 5: <plan task>`.
+- Add discovered follow-up tasks when hooks, audits, CI failures, or docs updates create real work. Do not add speculative items.
+- Before dispatching a subagent, mark the owned task in progress or add a concrete task-list item for that agent's assignment. When the subagent returns, update that item based on its result.
+- Keep the task list aligned with the committed or scratch plan. If the plan changes, update the task list in the same turn before executing the changed work.
+- In the end-of-turn summary, mention any task-list item that remains incomplete and why.
+
 ## Non-negotiables
 
 See `references/invariants.md` for the full list. Summary:

--- a/tests/unit/test-workbench-autopilot-skill.sh
+++ b/tests/unit/test-workbench-autopilot-skill.sh
@@ -157,31 +157,43 @@ else
 fi
 echo ""
 
-# Test 11: Plugin manifests at 0.9.0
-echo "Test 11: Plugin manifests at 0.9.0..."
+# Test 11: Autopilot task-list discipline
+echo "Test 11: Autopilot task-list discipline..."
+for term in 'Task List Discipline' 'TodoWrite' 'update_plan' 'exactly one item `in_progress`' 'After step 4 writes the implementation plan' 'Step 5: <plan task>' 'end-of-turn summary'; do
+    if grep -qF "$term" "$SKILL_MD"; then
+        echo "  [PASS] SKILL.md mentions $term"
+    else
+        echo "  [FAIL] SKILL.md missing task-list term: $term"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 12: Plugin manifests at 0.9.1
+echo "Test 12: Plugin manifests at 0.9.1..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.9.0"' "$CCM" >/dev/null && jq -e '.version == "0.9.0"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.9.0"
+if jq -e '.version == "0.9.1"' "$CCM" >/dev/null && jq -e '.version == "0.9.1"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.9.1"
 else
-    echo "  [FAIL] plugin manifests not at 0.9.0"
+    echo "  [FAIL] plugin manifests not at 0.9.1"
     exit 1
 fi
 echo ""
 
-# Test 12: Marketplace entries at 0.9.0
-echo "Test 12: Marketplace entries..."
+# Test 13: Marketplace entries at 0.9.1
+echo "Test 13: Marketplace entries..."
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.9.0"' "$MP" >/dev/null; then
-    echo "  [PASS] Claude marketplace workbench at 0.9.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.9.1"' "$MP" >/dev/null; then
+    echo "  [PASS] Claude marketplace workbench at 0.9.1"
 else
-    echo "  [FAIL] Claude marketplace workbench not at 0.9.0"
+    echo "  [FAIL] Claude marketplace workbench not at 0.9.1"
     exit 1
 fi
 echo ""
 
-# Test 13: Old claude-md-management skill IDs are absent from SKILL.md and required-skills.md
-echo "Test 13: Old claude-md-management skill IDs absent from autopilot files..."
+# Test 14: Old claude-md-management skill IDs are absent from SKILL.md and required-skills.md
+echo "Test 14: Old claude-md-management skill IDs absent from autopilot files..."
 RS="$SKILL_DIR/references/required-skills.md"
 for old_id in 'claude-md-management:revise-claude-md' 'claude-md-management:claude-md-improver'; do
     if grep -qF "$old_id" "$SKILL_MD"; then
@@ -199,8 +211,8 @@ for old_id in 'claude-md-management:revise-claude-md' 'claude-md-management:clau
 done
 echo ""
 
-# Test 14: required-skills.md has Step 3 row for writing-spec
-echo "Test 14: required-skills.md has Step 3 row for writing-spec..."
+# Test 15: required-skills.md has Step 3 row for writing-spec
+echo "Test 15: required-skills.md has Step 3 row for writing-spec..."
 RS="$SKILL_DIR/references/required-skills.md"
 if grep -qE '^\| 3 \| `workbench:writing-spec`' "$RS"; then
     echo "  [PASS] Step 3 row present in required-skills.md"


### PR DESCRIPTION
## Summary
- Add task-list discipline to the Workbench autopilot workflow.
- Require dynamic progress updates from bootstrap through implementation, subagents, audits, CI, and final reporting.
- Bump Workbench plugin metadata to 0.9.1 and cover the behavior in the autopilot unit test.

## Test plan
- [x] bash tests/unit/test-workbench-autopilot-skill.sh
- [x] bash tests/unit/test-skill-frontmatter-yaml.sh
- [x] bash tests/unit/test-codex-plugin-structure.sh
- [x] git diff --check
