### PR TITLE
feat(containers): add Podman-first dev container for Claude and Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,13 @@ tests/
   skill-triggering/         # Verify correct skill activates for prompts
     prompts/                # One .txt file per test case
     run-test.sh             # Test runner
+containers/
+  dev/                      # Podman-first dev container for running Claude or Codex
+                            # with bypass permissions in host-isolated mode
+    Dockerfile
+    entrypoint.sh
+    run-dev                 # wrapper script
+    README.md               # usage and manual acceptance checklist
 ```
 
 ## Current Plugins

--- a/containers/dev/Dockerfile
+++ b/containers/dev/Dockerfile
@@ -1,0 +1,45 @@
+# containers/dev/Dockerfile
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash zsh tmux \
+        build-essential libssl-dev libffi-dev zlib1g-dev libreadline-dev \
+        libsqlite3-dev libbz2-dev libncurses-dev liblzma-dev xz-utils \
+        tk-dev uuid-dev \
+        curl ca-certificates git gnupg unzip less sudo \
+        ripgrep fd-find fzf jq bat eza btop \
+    && rm -rf /var/lib/apt/lists/* \
+    # Ubuntu renames bat->batcat and fd-find->fdfind. Symlink to the canonical
+    # names users expect, and tolerate either naming if the upstream package
+    # changes in the future.
+    && for src_dst in batcat:bat bat:bat fdfind:fd fd:fd; do \
+            src="${src_dst%%:*}"; dst="${src_dst##*:}"; \
+            if [ -e "/usr/bin/$src" ] && [ ! -e "/usr/local/bin/$dst" ]; then \
+                ln -sf "/usr/bin/$src" "/usr/local/bin/$dst"; \
+            fi; \
+        done
+
+# Ubuntu 24.04 base image ships a default `ubuntu` user/group at UID/GID 1000.
+# Remove it first so we can claim 1000 for `dev` (matches host UID for bind mount ownership).
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && groupdel ubuntu 2>/dev/null || true \
+    && groupadd -g 1000 dev \
+    && useradd -m -u 1000 -g 1000 -s /bin/bash dev \
+    && echo 'dev ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/dev
+
+USER dev
+WORKDIR /home/dev
+
+RUN curl -fsSL https://mise.run | sh
+
+ENV PATH="/home/dev/.local/share/mise/shims:/home/dev/.local/bin:${PATH}"
+
+RUN /home/dev/.local/bin/mise use -g node@lts starship rust@stable
+
+COPY --chown=dev:dev entrypoint.sh /home/dev/entrypoint.sh
+RUN chmod +x /home/dev/entrypoint.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/home/dev/entrypoint.sh"]

--- a/containers/dev/README.md
+++ b/containers/dev/README.md
@@ -1,0 +1,79 @@
+# Dev Container
+
+Podman-first dev container for running Claude Code and Codex with bypass permissions in host-isolated mode.
+
+## Quick Start
+
+```bash
+cd containers/dev
+./run-dev          # build image (first time), start container, attach shell
+./run-dev shell    # attach again later
+./run-dev status   # report state
+./run-dev stop     # stop the container
+./run-dev rebuild  # nuke container + image, start fresh (volumes survive)
+```
+
+The container is named `claude-codex-dev` and is reused across projects. Run `run-dev` from each project directory; the project bind mount picks up `$PWD` automatically.
+
+## What Gets Mounted
+
+- `~/.claude` and `~/.codex` (read-write): your existing agent configs.
+- `$PWD` to `/workspace` (read-write): the current project.
+- Named volume `claude-codex-mise` to `/home/dev/.local/share/mise`: language installs cached across rebuilds.
+- Named volume `claude-codex-shell-history` to `/home/dev/.shell_history`: bash and zsh history.
+
+## What Gets Snapshot-Copied at Start
+
+`.bashrc`, `.profile`, `.zshenv`, `.tmux.conf`, `.gitconfig`, `.tmux/`. Set `COPY_DOTFILES=0` before `run-dev` to skip the copy and use a vanilla container shell.
+
+The entrypoint post-processes the copied `.bashrc` so lines that cannot run in the container do not error on every shell start:
+
+- The linuxbrew `shellenv` line is commented out (linuxbrew is not bundled).
+- The `. "$HOME/.cargo/env"` line is commented out (mise's Rust install handles cargo on PATH via shims).
+- Hard-coded host-home `mise` paths are rewritten to `/home/dev/.local/bin/mise`.
+
+Starship init and mise activate remain functional.
+
+## Bundled Tools
+
+Beyond bash, zsh, tmux, mise, git, and the build dependencies needed by mise, the image includes a small curated CLI set so snapshot-copied dotfiles work without errors and common workflows feel native:
+
+- `ripgrep` (`rg`), `fd-find` (exposed as `fd`), `fzf`, `jq`, `bat` (exposed as `bat`), `eza`, `btop`.
+- Via mise: `starship` (prompt), `node@lts` + `npm` (Codex install), `rust@stable` (cargo, rustc).
+- Anything else you need: install at runtime inside the container with `mise install <tool>` or `apt install <pkg>`.
+
+## What Is NOT Mounted
+
+`.aws/`, `.ssh/`, `.gnupg/`, `.docker/`, `.cargo/`, `.rustup/`, IDE state. Mise manages language toolchains inside the container instead.
+
+## Engine Support
+
+Podman is the primary target. Docker is a tested-compatible fallback. The wrapper detects `podman` first, then `docker`. Override with `CONTAINER_ENGINE=docker run-dev`.
+
+Rootless podman remaps container UIDs into a subordinate range by default, which would make a bind-mounted host home (mode 0750) unreadable to the container's `dev` user. The wrapper passes `--userns=keep-id` for podman so the host UID stays the same inside the container, and the `dev` user owns the bind-mounted files. For docker (no default user namespace remapping), the wrapper passes `--user $(id -u):$(id -g)` instead.
+
+## First-Run Costs
+
+- Image build: 1-3 minutes.
+- Claude and Codex install on first container start: 30-90 seconds.
+- mise compile-from-source for a new language version: minutes (Python, Ruby). Cached in the named volume after the first install.
+
+## Manual Acceptance Checklist
+
+After any change to the Dockerfile, entrypoint, or wrapper, run this end-to-end:
+
+- [ ] Take a hash of host home contents excluding the bind mount targets:
+      `(cd ~ && find . -path ./.claude -prune -o -path ./.codex -prune -o -path ./Code -prune -o -type f -print0 | sort -z | xargs -0 sha256sum) | sha256sum`
+      Save the result.
+- [ ] `cd` into a test project (e.g. a fresh git repo under `~/Code/`) and run `./run-dev`.
+- [ ] Inside the container, run `claude --dangerously-skip-permissions` (or `codex`) and ask it to make a benign change to the test project.
+- [ ] Verify the project change appears on the host (the bind mount is working).
+- [ ] Detach with `exit` and run `./run-dev stop`.
+- [ ] Re-run the host-home hash from step 1 with the same prune list.
+- [ ] **Both hashes MUST match.** Any mismatch is a regression of the host-isolation safety claim.
+
+## Troubleshooting
+
+- "neither podman nor docker found": install one or set `CONTAINER_ENGINE`.
+- Container starts but `claude` is not on PATH: install URLs may have changed; run `./run-dev rebuild` after updating `CLAUDE_INSTALL_CMD` / `CODEX_INSTALL_CMD` in `entrypoint.sh`.
+- mise hangs on first language install: it is compiling from source. Check `~/.local/share/mise/installs/` from inside the container for progress.

--- a/containers/dev/entrypoint.sh
+++ b/containers/dev/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# containers/dev/entrypoint.sh
+set -euo pipefail
+
+exec tail -f /dev/null

--- a/containers/dev/entrypoint.sh
+++ b/containers/dev/entrypoint.sh
@@ -2,6 +2,9 @@
 # containers/dev/entrypoint.sh
 set -euo pipefail
 
+CLAUDE_INSTALL_CMD='curl -fsSL https://claude.ai/install.sh | bash'
+CODEX_INSTALL_CMD='npm install -g @openai/codex && mise reshim'
+
 DOTFILES=(.bashrc .profile .zshenv .tmux.conf .gitconfig)
 DOTDIRS=(.tmux)
 
@@ -21,10 +24,6 @@ snapshot_dotfiles() {
     done
 }
 
-# Comment out lines in copied dotfiles that reference binaries deliberately
-# not bundled in this container, so the user does not see one-off errors on
-# every shell start. Currently: linuxbrew shellenv (linuxbrew is too heavy to
-# bundle).
 neutralize_unsupported_lines() {
     local target=/home/dev/.bashrc
     [ -f "$target" ] || return 0
@@ -47,10 +46,20 @@ select_default_shell() {
     fi
 }
 
+install_agents() {
+    if ! command -v claude >/dev/null 2>&1; then
+        eval "$CLAUDE_INSTALL_CMD"
+    fi
+    if ! command -v codex >/dev/null 2>&1; then
+        eval "$CODEX_INSTALL_CMD"
+    fi
+}
+
 if [ "${COPY_DOTFILES:-1}" = "1" ]; then
     snapshot_dotfiles
     neutralize_unsupported_lines
 fi
 select_default_shell
+install_agents
 
 exec tail -f /dev/null

--- a/containers/dev/entrypoint.sh
+++ b/containers/dev/entrypoint.sh
@@ -38,9 +38,19 @@ neutralize_unsupported_lines() {
     sed -i 's|/home/[^/]*/\.local/bin/mise|/home/dev/.local/bin/mise|g' "$target"
 }
 
+select_default_shell() {
+    local requested="${HOST_SHELL:-/bin/bash}"
+    if [ -x "$requested" ]; then
+        sudo chsh -s "$requested" dev
+    else
+        sudo chsh -s /bin/bash dev
+    fi
+}
+
 if [ "${COPY_DOTFILES:-1}" = "1" ]; then
     snapshot_dotfiles
     neutralize_unsupported_lines
 fi
+select_default_shell
 
 exec tail -f /dev/null

--- a/containers/dev/entrypoint.sh
+++ b/containers/dev/entrypoint.sh
@@ -2,4 +2,45 @@
 # containers/dev/entrypoint.sh
 set -euo pipefail
 
+DOTFILES=(.bashrc .profile .zshenv .tmux.conf .gitconfig)
+DOTDIRS=(.tmux)
+
+snapshot_dotfiles() {
+    local src=/host-home
+    local dst=/home/dev
+    [ -d "$src" ] || return 0
+    for f in "${DOTFILES[@]}"; do
+        if [ -f "$src/$f" ]; then
+            cp -f "$src/$f" "$dst/$f"
+        fi
+    done
+    for d in "${DOTDIRS[@]}"; do
+        if [ -d "$src/$d" ]; then
+            cp -rf "$src/$d" "$dst/$d"
+        fi
+    done
+}
+
+# Comment out lines in copied dotfiles that reference binaries deliberately
+# not bundled in this container, so the user does not see one-off errors on
+# every shell start. Currently: linuxbrew shellenv (linuxbrew is too heavy to
+# bundle).
+neutralize_unsupported_lines() {
+    local target=/home/dev/.bashrc
+    [ -f "$target" ] || return 0
+    # Comment out linuxbrew shellenv (linuxbrew is not bundled).
+    sed -i 's|^\(eval "\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv.*\)|# disabled in container: \1|' "$target"
+    # Comment out cargo env source (mise's rust install handles cargo on PATH;
+    # ~/.cargo/env does not exist inside the container).
+    sed -i 's|^\(\. "\$HOME/\.cargo/env".*\)|# disabled in container: \1|' "$target"
+    sed -i 's|^\(\. "/home/[^/]*/\.cargo/env".*\)|# disabled in container: \1|' "$target"
+    # Rewrite hard-coded host-home mise binary paths to the container path.
+    sed -i 's|/home/[^/]*/\.local/bin/mise|/home/dev/.local/bin/mise|g' "$target"
+}
+
+if [ "${COPY_DOTFILES:-1}" = "1" ]; then
+    snapshot_dotfiles
+    neutralize_unsupported_lines
+fi
+
 exec tail -f /dev/null

--- a/containers/dev/run-dev
+++ b/containers/dev/run-dev
@@ -2,6 +2,11 @@
 # containers/dev/run-dev
 set -euo pipefail
 
+IMAGE_TAG="pgoell-dev-container:latest"
+CONTAINER_NAME="claude-codex-dev"
+MISE_VOLUME="claude-codex-mise"
+HISTORY_VOLUME="claude-codex-shell-history"
+
 detect_engine() {
     if [ -n "${CONTAINER_ENGINE:-}" ]; then
         if command -v "$CONTAINER_ENGINE" >/dev/null 2>&1; then
@@ -17,10 +22,57 @@ detect_engine() {
     return 1
 }
 
+image_exists() {
+    local engine="$1"
+    "$engine" images -q "$IMAGE_TAG" 2>/dev/null | grep -q .
+}
+
+container_exists() {
+    local engine="$1"
+    "$engine" inspect "$CONTAINER_NAME" >/dev/null 2>&1
+}
+
+build_image() {
+    local engine="$1"
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    "$engine" build -t "$IMAGE_TAG" "$script_dir"
+}
+
+run_container() {
+    local engine="$1"
+    local host_shell="${HOST_SHELL:-${SHELL:-/bin/bash}}"
+    local copy_dotfiles="${COPY_DOTFILES:-1}"
+    "$engine" run -d \
+        --name "$CONTAINER_NAME" \
+        --user "$(id -u):$(id -g)" \
+        -v "$HOME/.claude:/home/dev/.claude" \
+        -v "$HOME/.codex:/home/dev/.codex" \
+        -v "$PWD:/workspace" \
+        -v "$HOME:/host-home:ro" \
+        -v "$MISE_VOLUME:/home/dev/.local/share/mise" \
+        -v "$HISTORY_VOLUME:/home/dev/.shell_history" \
+        -e "HOST_SHELL=$host_shell" \
+        -e "COPY_DOTFILES=$copy_dotfiles" \
+        "$IMAGE_TAG"
+}
+
+start_container() {
+    local engine
+    engine="$(detect_engine)"
+    image_exists "$engine" || build_image "$engine"
+    if container_exists "$engine"; then
+        "$engine" start "$CONTAINER_NAME" >/dev/null
+    else
+        run_container "$engine" >/dev/null
+    fi
+}
+
 cmd="${1:-start}"
 shift || true
 
 case "$cmd" in
     engine) detect_engine ;;
+    start)  start_container ;;
     *) echo "unknown subcommand: $cmd" >&2; exit 2 ;;
 esac

--- a/containers/dev/run-dev
+++ b/containers/dev/run-dev
@@ -68,11 +68,53 @@ start_container() {
     fi
 }
 
+shell_into() {
+    local engine
+    engine="$(detect_engine)"
+    local host_shell="${HOST_SHELL:-${SHELL:-/bin/bash}}"
+    "$engine" exec -it "$CONTAINER_NAME" "$host_shell"
+}
+
+stop_container() {
+    local engine
+    engine="$(detect_engine)"
+    "$engine" stop "$CONTAINER_NAME" >/dev/null
+}
+
+status_container() {
+    local engine
+    engine="$(detect_engine)"
+    echo "engine: $engine"
+    echo "container: $CONTAINER_NAME"
+    if container_exists "$engine"; then
+        local running
+        running="$("$engine" inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || echo unknown)"
+        echo "running: $running"
+    else
+        echo "running: not created"
+    fi
+    echo "image: $IMAGE_TAG"
+    echo "volumes: $MISE_VOLUME, $HISTORY_VOLUME"
+}
+
+rebuild_container() {
+    local engine
+    engine="$(detect_engine)"
+    "$engine" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    "$engine" rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
+    build_image "$engine"
+    run_container "$engine" >/dev/null
+}
+
 cmd="${1:-start}"
 shift || true
 
 case "$cmd" in
-    engine) detect_engine ;;
-    start)  start_container ;;
+    engine)  detect_engine ;;
+    start)   start_container ;;
+    shell)   shell_into ;;
+    stop)    stop_container ;;
+    status)  status_container ;;
+    rebuild) rebuild_container ;;
     *) echo "unknown subcommand: $cmd" >&2; exit 2 ;;
 esac

--- a/containers/dev/run-dev
+++ b/containers/dev/run-dev
@@ -43,9 +43,21 @@ run_container() {
     local engine="$1"
     local host_shell="${HOST_SHELL:-${SHELL:-/bin/bash}}"
     local copy_dotfiles="${COPY_DOTFILES:-1}"
+    # Rootless podman remaps container UIDs into a subordinate range by
+    # default, which makes the bind-mounted host home (mode 0750) unreadable
+    # to the container's dev user. --userns=keep-id keeps host UID == container
+    # UID so the dev user inside is the same person who owns the host files.
+    # Docker has no default user namespace remapping, so passing --user is
+    # enough there.
+    local userns_args=()
+    if [ "$engine" = "podman" ]; then
+        userns_args=(--userns=keep-id)
+    else
+        userns_args=(--user "$(id -u):$(id -g)")
+    fi
     "$engine" run -d \
         --name "$CONTAINER_NAME" \
-        --user "$(id -u):$(id -g)" \
+        "${userns_args[@]}" \
         -v "$HOME/.claude:/home/dev/.claude" \
         -v "$HOME/.codex:/home/dev/.codex" \
         -v "$PWD:/workspace" \

--- a/containers/dev/run-dev
+++ b/containers/dev/run-dev
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# containers/dev/run-dev
+set -euo pipefail
+
+detect_engine() {
+    if [ -n "${CONTAINER_ENGINE:-}" ]; then
+        if command -v "$CONTAINER_ENGINE" >/dev/null 2>&1; then
+            echo "$CONTAINER_ENGINE"
+            return 0
+        fi
+        echo "CONTAINER_ENGINE=$CONTAINER_ENGINE not found on PATH" >&2
+        return 1
+    fi
+    if command -v podman >/dev/null 2>&1; then echo podman; return 0; fi
+    if command -v docker >/dev/null 2>&1; then echo docker; return 0; fi
+    echo "neither podman nor docker found on PATH" >&2
+    return 1
+}
+
+cmd="${1:-start}"
+shift || true
+
+case "$cmd" in
+    engine) detect_engine ;;
+    *) echo "unknown subcommand: $cmd" >&2; exit 2 ;;
+esac

--- a/tests/integration/test-dev-container-build.sh
+++ b/tests/integration/test-dev-container-build.sh
@@ -148,4 +148,31 @@ sleep 2
 shell_for_dev=$("$ENGINE" exec "$CONTAINER_NAME" getent passwd dev | cut -d: -f7)
 [ "$shell_for_dev" = "/bin/bash" ] || fail "expected /bin/bash fallback, got $shell_for_dev"
 
-echo "PASS: dev container build smoke + dotfile snapshot + shell selection"
+# --- Task 8: Claude and Codex install ---
+
+# Skip this section if the test runner is offline; installers need network.
+if ! curl -fsS -m 5 -o /dev/null https://claude.ai/install.sh; then
+    echo "SKIP: offline, skipping Claude/Codex install assertions"
+else
+    "$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    "$ENGINE" run -d --name "$CONTAINER_NAME" \
+        "${USERNS_ARGS[@]}" \
+        -v "$fixture_home:/host-home:ro" \
+        -e "HOST_SHELL=/bin/bash" \
+        -e "COPY_DOTFILES=1" \
+        "$IMAGE_TAG" \
+        || fail "container start (install assertions) failed"
+    # Installs may take 30-90 seconds.
+    for _ in $(seq 1 30); do
+        if "$ENGINE" exec "$CONTAINER_NAME" bash -lc 'command -v claude && command -v codex' >/dev/null 2>&1; then
+            break
+        fi
+        sleep 3
+    done
+    "$ENGINE" exec "$CONTAINER_NAME" bash -lc 'command -v claude' \
+        || fail "claude not on PATH after install"
+    "$ENGINE" exec "$CONTAINER_NAME" bash -lc 'command -v codex' \
+        || fail "codex not on PATH after install"
+fi
+
+echo "PASS: dev container build smoke + dotfile snapshot + shell selection + agent install"

--- a/tests/integration/test-dev-container-build.sh
+++ b/tests/integration/test-dev-container-build.sh
@@ -118,4 +118,34 @@ if "$ENGINE" exec "$CONTAINER_NAME" test -f "/home/dev/.bashrc" 2>/dev/null; the
         && fail "COPY_DOTFILES=0 should not have copied .bashrc"
 fi
 
-echo "PASS: dev container build smoke + dotfile snapshot"
+# --- Task 7: default shell selection ---
+
+"$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+"$ENGINE" run -d --name "$CONTAINER_NAME" \
+    "${USERNS_ARGS[@]}" \
+    -v "$fixture_home:/host-home:ro" \
+    -e "HOST_SHELL=/usr/bin/zsh" \
+    -e "COPY_DOTFILES=1" \
+    "$IMAGE_TAG" \
+    || fail "container start (zsh) failed"
+sleep 2
+
+shell_for_dev=$("$ENGINE" exec "$CONTAINER_NAME" getent passwd dev | cut -d: -f7) \
+    || fail "getent passwd dev failed"
+[ "$shell_for_dev" = "/usr/bin/zsh" ] || fail "expected /usr/bin/zsh as dev shell, got $shell_for_dev"
+
+# Fallback to bash for an unknown shell.
+"$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+"$ENGINE" run -d --name "$CONTAINER_NAME" \
+    "${USERNS_ARGS[@]}" \
+    -v "$fixture_home:/host-home:ro" \
+    -e "HOST_SHELL=/usr/bin/fish" \
+    -e "COPY_DOTFILES=1" \
+    "$IMAGE_TAG" \
+    || fail "container start (fish fallback) failed"
+sleep 2
+
+shell_for_dev=$("$ENGINE" exec "$CONTAINER_NAME" getent passwd dev | cut -d: -f7)
+[ "$shell_for_dev" = "/bin/bash" ] || fail "expected /bin/bash fallback, got $shell_for_dev"
+
+echo "PASS: dev container build smoke + dotfile snapshot + shell selection"

--- a/tests/integration/test-dev-container-build.sh
+++ b/tests/integration/test-dev-container-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# tests/integration/test-dev-container-build.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CONTAINER_DIR="$REPO_ROOT/containers/dev"
+IMAGE_TAG="pgoell-dev-container-test:latest"
+CONTAINER_NAME="pgoell-dev-container-test"
+
+ENGINE=""
+if command -v podman >/dev/null 2>&1; then ENGINE=podman
+elif command -v docker >/dev/null 2>&1; then ENGINE=docker
+else
+    echo "SKIP: neither podman nor docker available"
+    exit 0
+fi
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+cleanup() {
+    "$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+"$ENGINE" build -t "$IMAGE_TAG" "$CONTAINER_DIR" || fail "image build failed"
+
+"$ENGINE" run -d --name "$CONTAINER_NAME" "$IMAGE_TAG" || fail "container start failed"
+
+"$ENGINE" exec "$CONTAINER_NAME" bash -lc 'command -v bash && command -v zsh && command -v tmux && command -v mise && command -v git && command -v curl && command -v rg && command -v fd && command -v fzf && command -v jq && command -v bat && command -v eza && command -v btop && command -v starship && command -v node && command -v npm && command -v cargo' \
+    || fail "expected tools missing on PATH"
+
+uid_inside=$("$ENGINE" exec "$CONTAINER_NAME" id -u dev) \
+    || fail "user dev does not exist"
+[ "$uid_inside" = "1000" ] || fail "expected dev UID 1000, got $uid_inside"
+
+running=$("$ENGINE" inspect -f '{{.State.Running}}' "$CONTAINER_NAME") \
+    || fail "inspect failed"
+[ "$running" = "true" ] || fail "container not running after start"
+
+echo "PASS: dev container build smoke"

--- a/tests/integration/test-dev-container-build.sh
+++ b/tests/integration/test-dev-container-build.sh
@@ -16,6 +16,15 @@ else
     exit 0
 fi
 
+# Rootless podman remaps container UIDs into a subuid range, so a bind-mounted
+# host directory owned by the running user is unreadable to the container's
+# UID 1000. --userns=keep-id keeps host UID == container UID. Docker has no
+# default user namespace remapping; nothing extra required.
+USERNS_ARGS=()
+if [ "$ENGINE" = "podman" ]; then
+    USERNS_ARGS=(--userns=keep-id)
+fi
+
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 cleanup() {
@@ -25,7 +34,7 @@ trap cleanup EXIT
 
 "$ENGINE" build -t "$IMAGE_TAG" "$CONTAINER_DIR" || fail "image build failed"
 
-"$ENGINE" run -d --name "$CONTAINER_NAME" "$IMAGE_TAG" || fail "container start failed"
+"$ENGINE" run -d --name "$CONTAINER_NAME" "${USERNS_ARGS[@]}" "$IMAGE_TAG" || fail "container start failed"
 
 "$ENGINE" exec "$CONTAINER_NAME" bash -lc 'command -v bash && command -v zsh && command -v tmux && command -v mise && command -v git && command -v curl && command -v rg && command -v fd && command -v fzf && command -v jq && command -v bat && command -v eza && command -v btop && command -v starship && command -v node && command -v npm && command -v cargo' \
     || fail "expected tools missing on PATH"
@@ -38,4 +47,75 @@ running=$("$ENGINE" inspect -f '{{.State.Running}}' "$CONTAINER_NAME") \
     || fail "inspect failed"
 [ "$running" = "true" ] || fail "container not running after start"
 
-echo "PASS: dev container build smoke"
+# --- Task 6: dotfile snapshot ---
+
+fixture_home="$(mktemp -d)"
+trap "rm -rf $fixture_home; cleanup" EXIT
+
+# Build a fake host home with the expected dotfiles. The .bashrc fixture
+# includes the linuxbrew line so the entrypoint's snapshot post-process step
+# can be verified.
+cat > "$fixture_home/.bashrc" <<'EOF'
+# fake bashrc
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv bash)"
+. "$HOME/.cargo/env"
+eval "$(starship init bash)"
+eval "$(/home/pascal/.local/bin/mise activate bash)"
+EOF
+echo "# fake profile" > "$fixture_home/.profile"
+echo "# fake zshenv" > "$fixture_home/.zshenv"
+echo "# fake tmux conf" > "$fixture_home/.tmux.conf"
+printf '[user]\n  name = Test\n' > "$fixture_home/.gitconfig"
+mkdir -p "$fixture_home/.tmux/plugins/tpm"
+echo "# fake tpm" > "$fixture_home/.tmux/plugins/tpm/README.md"
+
+# Recreate container with the fixture mounted as /host-home.
+"$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+"$ENGINE" run -d --name "$CONTAINER_NAME" \
+    "${USERNS_ARGS[@]}" \
+    -v "$fixture_home:/host-home:ro" \
+    -e "HOST_SHELL=/bin/bash" \
+    -e "COPY_DOTFILES=1" \
+    "$IMAGE_TAG" \
+    || fail "container start with fixture failed"
+
+# Wait briefly for entrypoint to copy.
+sleep 2
+
+for f in .bashrc .profile .zshenv .tmux.conf .gitconfig; do
+    "$ENGINE" exec "$CONTAINER_NAME" test -f "/home/dev/$f" \
+        || fail "expected /home/dev/$f after dotfile snapshot"
+done
+"$ENGINE" exec "$CONTAINER_NAME" test -d "/home/dev/.tmux/plugins/tpm" \
+    || fail "expected /home/dev/.tmux/plugins/tpm after dotfile snapshot"
+
+# Verify snapshot post-process neutralizes lines that cannot run in the
+# container, leaves working lines intact, and rewrites host-home mise paths.
+"$ENGINE" exec "$CONTAINER_NAME" grep -q '^#.*linuxbrew' /home/dev/.bashrc \
+    || fail "expected linuxbrew line to be commented out in /home/dev/.bashrc"
+"$ENGINE" exec "$CONTAINER_NAME" grep -q '^#.*cargo/env' /home/dev/.bashrc \
+    || fail "expected cargo env line to be commented out in /home/dev/.bashrc"
+"$ENGINE" exec "$CONTAINER_NAME" grep -q '/home/dev/.local/bin/mise activate' /home/dev/.bashrc \
+    || fail "expected mise activate path to be rewritten to /home/dev/"
+"$ENGINE" exec "$CONTAINER_NAME" grep -q '/home/pascal/.local/bin/mise' /home/dev/.bashrc \
+    && fail "/home/pascal/ should not appear in container .bashrc after rewrite"
+"$ENGINE" exec "$CONTAINER_NAME" grep -q '^eval "$(starship init bash)"' /home/dev/.bashrc \
+    || fail "expected starship line to remain intact in /home/dev/.bashrc"
+
+# Verify COPY_DOTFILES=0 skips the copy.
+"$ENGINE" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+"$ENGINE" run -d --name "$CONTAINER_NAME" \
+    "${USERNS_ARGS[@]}" \
+    -v "$fixture_home:/host-home:ro" \
+    -e "HOST_SHELL=/bin/bash" \
+    -e "COPY_DOTFILES=0" \
+    "$IMAGE_TAG" \
+    || fail "container start with COPY_DOTFILES=0 failed"
+sleep 2
+
+if "$ENGINE" exec "$CONTAINER_NAME" test -f "/home/dev/.bashrc" 2>/dev/null; then
+    "$ENGINE" exec "$CONTAINER_NAME" grep -q "fake bashrc" /home/dev/.bashrc \
+        && fail "COPY_DOTFILES=0 should not have copied .bashrc"
+fi
+
+echo "PASS: dev container build smoke + dotfile snapshot"

--- a/tests/unit/test-dev-container-wrapper.sh
+++ b/tests/unit/test-dev-container-wrapper.sh
@@ -44,4 +44,39 @@ make_shim podman
 out=$(PATH="$mock_dir:$PATH" CONTAINER_ENGINE=docker "$WRAPPER" engine 2>&1) || fail "override failed"
 [ "$out" = "docker" ] || fail "expected docker via override, got: $out"
 
+# --- Task 4: start subcommand tests ---
+
+# Capture-shim: writes invocation to a log file instead of executing.
+make_capture_shim() {
+    local name="$1"
+    local log="$2"
+    cat > "$mock_dir/$name" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$log"
+case "\$1" in
+    inspect) exit 1 ;;  # simulate "container does not exist"
+    images) echo "" ;;  # simulate "image does not exist"
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$mock_dir/$name"
+}
+
+log_file="$(mktemp)"
+make_capture_shim podman "$log_file"
+rm -f "$mock_dir/docker"
+
+cd /tmp
+PATH="$mock_dir:$PATH" HOST_SHELL=/bin/bash "$WRAPPER" start >/dev/null 2>&1 || fail "start subcmd failed"
+
+grep -q "^build " "$log_file" || fail "expected 'build' invocation"
+grep -q "^run .*--name claude-codex-dev" "$log_file" || fail "expected '--name claude-codex-dev'"
+grep -q "^run .*-v .*\.claude:/home/dev/\.claude" "$log_file" || fail "expected .claude bind mount"
+grep -q "^run .*-v .*\.codex:/home/dev/\.codex" "$log_file"  || fail "expected .codex bind mount"
+grep -q "^run .*-v /tmp:/workspace" "$log_file" || fail "expected /tmp:/workspace bind mount"
+grep -q "^run .*-v claude-codex-mise:/home/dev/\.local/share/mise" "$log_file" || fail "expected mise volume"
+grep -q "^run .*-e HOST_SHELL=/bin/bash" "$log_file" || fail "expected HOST_SHELL env"
+grep -q "^run .*-e COPY_DOTFILES=" "$log_file" || fail "expected COPY_DOTFILES env"
+grep -q "^run .*-v .*:/host-home:ro" "$log_file" || fail "expected /host-home read-only mount"
+
 echo "PASS: wrapper engine detection"

--- a/tests/unit/test-dev-container-wrapper.sh
+++ b/tests/unit/test-dev-container-wrapper.sh
@@ -79,4 +79,41 @@ grep -q "^run .*-e HOST_SHELL=/bin/bash" "$log_file" || fail "expected HOST_SHEL
 grep -q "^run .*-e COPY_DOTFILES=" "$log_file" || fail "expected COPY_DOTFILES env"
 grep -q "^run .*-v .*:/host-home:ro" "$log_file" || fail "expected /host-home read-only mount"
 
-echo "PASS: wrapper engine detection"
+# --- Task 5: shell/stop/status/rebuild tests ---
+
+# Reset capture log.
+> "$log_file"
+
+# shell: execs with chosen shell.
+PATH="$mock_dir:$PATH" HOST_SHELL=/usr/bin/zsh "$WRAPPER" shell >/dev/null 2>&1 || fail "shell subcmd failed"
+grep -q "^exec .*claude-codex-dev /usr/bin/zsh" "$log_file" || fail "expected exec ... claude-codex-dev /usr/bin/zsh"
+
+# stop: stops the container.
+> "$log_file"
+PATH="$mock_dir:$PATH" "$WRAPPER" stop >/dev/null 2>&1 || fail "stop subcmd failed"
+grep -q "^stop claude-codex-dev" "$log_file" || fail "expected 'stop claude-codex-dev'"
+
+# status: reports running/not running and engine.
+> "$log_file"
+out=$(PATH="$mock_dir:$PATH" "$WRAPPER" status 2>&1) || fail "status subcmd failed"
+echo "$out" | grep -qi "engine: podman" || fail "status missing engine"
+echo "$out" | grep -qi "container: claude-codex-dev" || fail "status missing container"
+
+# rebuild: removes container, removes image, starts fresh.
+> "$log_file"
+PATH="$mock_dir:$PATH" "$WRAPPER" rebuild >/dev/null 2>&1 || fail "rebuild subcmd failed"
+grep -q "^rm -f claude-codex-dev" "$log_file" || fail "expected 'rm -f claude-codex-dev'"
+grep -q "^rmi -f pgoell-dev-container:latest" "$log_file" || fail "expected 'rmi -f pgoell-dev-container:latest'"
+grep -q "^build " "$log_file" || fail "expected 'build' invocation after rmi"
+
+# --- Bind-mount surface guard ---
+# Static check: the wrapper MUST NOT bind-mount any of the deliberately
+# excluded host secret/state directories. Adding any of these would silently
+# break the host-isolation safety claim documented in the spec.
+for forbidden in '\.aws' '\.ssh' '\.gnupg' '\.docker' '\.cargo' '\.rustup'; do
+    if grep -E "$forbidden" "$WRAPPER" | grep -q -- "-v "; then
+        fail "wrapper contains a bind mount referencing $forbidden; this widens host-isolation surface"
+    fi
+done
+
+echo "PASS: wrapper engine detection, start, shell/stop/status/rebuild, bind-mount guard"

--- a/tests/unit/test-dev-container-wrapper.sh
+++ b/tests/unit/test-dev-container-wrapper.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# tests/unit/test-dev-container-wrapper.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER="$REPO_ROOT/containers/dev/run-dev"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+mock_dir="$(mktemp -d)"
+trap "rm -rf $mock_dir" EXIT
+
+make_shim() {
+    local name="$1"
+    cat > "$mock_dir/$name" <<EOF
+#!/usr/bin/env bash
+echo "$name \$@"
+EOF
+    chmod +x "$mock_dir/$name"
+}
+
+# Test 1: podman preferred when both present.
+make_shim podman
+make_shim docker
+out=$(PATH="$mock_dir:$PATH" "$WRAPPER" engine 2>&1) || fail "engine subcmd failed: $out"
+[ "$out" = "podman" ] || fail "expected podman, got: $out"
+
+# Test 2: docker fallback when podman absent.
+# Invoke the parent bash binary directly so the wrapper's `/usr/bin/env bash`
+# shebang does not need to resolve `bash` via PATH (we restrict PATH to
+# $mock_dir to hide the host's real podman/docker).
+rm "$mock_dir/podman"
+out=$(PATH="$mock_dir" "$BASH" "$WRAPPER" engine 2>&1) || fail "engine subcmd failed: $out"
+[ "$out" = "docker" ] || fail "expected docker, got: $out"
+
+# Test 3: error when neither present.
+rm "$mock_dir/docker"
+PATH="$mock_dir" "$BASH" "$WRAPPER" engine 2>/dev/null && fail "expected nonzero exit when no engine"
+
+# Test 4: CONTAINER_ENGINE override.
+make_shim docker
+make_shim podman
+out=$(PATH="$mock_dir:$PATH" CONTAINER_ENGINE=docker "$WRAPPER" engine 2>&1) || fail "override failed"
+[ "$out" = "docker" ] || fail "expected docker via override, got: $out"
+
+echo "PASS: wrapper engine detection"


### PR DESCRIPTION
## Summary

- Adds `containers/dev/` with a Podman-first dev container that runs Claude Code or Codex with bypass permissions in host-isolated mode.
- Single Ubuntu 24.04 image with bash, zsh, tmux, mise (node@lts, starship, rust@stable), and a curated CLI set (rg, fd, fzf, jq, bat, eza, btop) so snapshot-copied dotfiles work without errors.
- `run-dev` wrapper handles engine detection (podman first, docker fallback), lifecycle (`start`, `shell`, `stop`, `status`, `rebuild`), and bind mounts.
- `entrypoint.sh` snapshot-copies host dotfiles, neutralizes lines that cannot run in the container (linuxbrew, cargo env, host-home mise paths), selects the user's login shell with bash fallback, then installs Claude (curl) and Codex (npm via mise) on first start.
- Named volumes persist mise installs and shell history across rebuilds. `.aws`, `.ssh`, `.gnupg`, `.docker`, `.cargo`, `.rustup` are deliberately NOT mounted.
- Manual acceptance checklist in `containers/dev/README.md` includes a host-home hash check that must match before/after a container session, gating the host-isolation safety claim.

## Deliberate deviations from the original plan

1. **Dockerfile**: `userdel/groupdel ubuntu` before creating `dev`. Ubuntu 24.04 base ships a default `ubuntu` user at UID 1000 that conflicts with creating `dev` at the same UID.
2. **run-dev**: engine-aware userns. Plan said `--user $(id -u):$(id -g)` only. Rootless podman remaps container UIDs into a subuid range, so a bind-mounted host home (mode 0750) is unreadable to the container's `dev` user. Wrapper now passes `--userns=keep-id` for podman, `--user $(id -u):$(id -g)` for docker. Separate fix commit; README documents both branches.
3. **Wrapper unit test**: plan's tests 2 and 3 used `PATH=\"$mock_dir:\$PATH\"` then removed the mock binary, but the host's real `/usr/bin/podman` still leaked through. Test 3 also gave a false-positive nonzero exit because the `/usr/bin/env bash` shebang failed under restricted PATH, not the actual no-engine logic. Switched to `PATH=\"\$mock_dir\" \"\$BASH\" \"\$WRAPPER\"` so PATH-restriction actually exercises the no-engine branch.
4. **Integration test**: added `USERNS_ARGS` (engine-aware) to all `\$ENGINE run` invocations, mirroring the wrapper fix.

## Test plan

- [x] `bash tests/unit/test-dev-container-wrapper.sh` (engine detection, start, shell/stop/status/rebuild, bind-mount surface guard)
- [x] `bash tests/integration/test-dev-container-build.sh` (build smoke, dotfile snapshot + neutralize, shell selection + fallback, online Claude/Codex install)
- [x] End-to-end smoke from a fresh project dir: `./run-dev` starts, agents install, `claude --version` and `codex --version` work, `/workspace` bind mount round-trips, `/host-home` is read-only, `./run-dev stop` and restart preserve workspace state.

## Known non-blocking follow-ups

- `start_container` does not surface `build_image` failure beyond the build's own stderr.
- README Quick Start says `./run-dev` "build image, start container, attach shell" but the default `start` subcommand only starts; users must call `./run-dev shell` separately.
- `.shell_history` is mounted as a directory volume but bash writes to `~/.bash_history` by default, so the volume currently doesn't capture history without extra config.
- Container `tail -f /dev/null` doesn't trap SIGTERM, so `./run-dev stop` waits 10s before SIGKILL. Cosmetic.