### PR TITLE
fix(frontend-design): restore dropped emil-design-eng sections and fix stale unit-test version pins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -56,7 +56,7 @@
       "name": "frontend-design",
       "source": "./plugins/frontend-design",
       "description": "Create distinctive, production-grade frontend interfaces with deep UI craft and animation discipline.",
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "name": "playground",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ containers/
 | `agent-system-management` | 0.4.2 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
 | `workbench` | 0.16.1 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`, `systematic-debugging`, `crafting-html`, `crafting-design-systems`, `crafting-presentations` |
 | `terminal` | 0.1.0 | `tmux` |
-| `frontend-design` | 0.2.0 | `frontend-design` (ported from Anthropic, Apache 2.0 upstream), `emil-design-eng` (ported from emilkowalski/skill, no upstream license declared) |
+| `frontend-design` | 0.2.1 | `frontend-design` (ported from Anthropic, Apache 2.0 upstream), `emil-design-eng` (ported from emilkowalski/skill, no upstream license declared) |
 | `playground` | 0.1.0 | `playground` (ported from Anthropic, Apache 2.0 upstream) |
 | `databricks` | 0.3.0 | `databricks-core` (ported from databricks/databricks-agent-skills under upstream Databricks License, restricted to Databricks Services), `databricks-docs` |
 

--- a/plugins/frontend-design/.claude-plugin/plugin.json
+++ b/plugins/frontend-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Create distinctive, production-grade frontend interfaces with deep UI craft and animation discipline.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/frontend-design/.codex-plugin/plugin.json
+++ b/plugins/frontend-design/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Create distinctive, production-grade frontend interfaces with deep UI craft and animation discipline.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/frontend-design/skills/emil-design-eng/SKILL.md
+++ b/plugins/frontend-design/skills/emil-design-eng/SKILL.md
@@ -5,6 +5,14 @@ description: This skill encodes Emil Kowalski's philosophy on UI polish, compone
 
 # Design Engineering
 
+## Initial Response
+
+When this skill is first invoked without a specific question, respond only with:
+
+> I'm ready to help you build interfaces that feel right, my knowledge comes from Emil Kowalski's design engineering philosophy. If you want to dive even deeper, check out Emil's course: [animations.dev](https://animations.dev/).
+
+Do not provide any other information until the user asks a question.
+
 You are a design engineer with the craft sensibility. You build interfaces where every detail compounds into something that feels right. You understand that in a world where everyone's software is good enough, taste is the differentiator.
 
 ## Core Philosophy
@@ -38,6 +46,18 @@ When reviewing UI code, you MUST use a markdown table with Before/After columns.
 | `ease-in` on dropdown | `ease-out` with custom curve | `ease-in` feels sluggish; `ease-out` gives instant feedback |
 | No `:active` state on button | `transform: scale(0.97)` on `:active` | Buttons must feel responsive to press |
 | `transform-origin: center` on popover | `transform-origin: var(--radix-popover-content-transform-origin)` | Popovers should scale from their trigger (not modals, modals stay centered) |
+
+Wrong format (never do this):
+
+```
+Before: transition: all 300ms
+After: transition: transform 200ms ease-out
+────────────────────────────
+Before: scale(0)
+After: scale(0.95)
+```
+
+Correct format: A single markdown table with | Before | After | Why | columns, one row per issue found. The "Why" column briefly explains the reasoning.
 
 ## Reference Docs
 

--- a/tests/unit/test-frontend-design-emil-skill.sh
+++ b/tests/unit/test-frontend-design-emil-skill.sh
@@ -2,7 +2,7 @@
 # Test: frontend-design plugin's emil-design-eng skill structure
 # Verifies the port of emilkowalski/skill: SKILL.md exists with all expected
 # headings, no em-dashes/en-dashes, animations.dev attribution preserved,
-# NOTICE attributes the upstream, plugin manifests bumped to 0.2.0.
+# NOTICE attributes the upstream, plugin manifests bumped to 0.2.1.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -22,28 +22,28 @@ MARKETPLACE="$REPO_ROOT/.claude-plugin/marketplace.json"
 echo "=== Test: frontend-design emil-design-eng skill structure ==="
 echo ""
 
-# Test 1: Plugin manifests bumped to 0.2.0
-echo "Test 1: Plugin manifests at 0.2.0..."
-if jq -e '.version == "0.2.0"' "$PLUGIN_JSON" >/dev/null; then
-    echo "  [PASS] Claude manifest at 0.2.0"
+# Test 1: Plugin manifests bumped to 0.2.1
+echo "Test 1: Plugin manifests at 0.2.1..."
+if jq -e '.version == "0.2.1"' "$PLUGIN_JSON" >/dev/null; then
+    echo "  [PASS] Claude manifest at 0.2.1"
 else
-    echo "  [FAIL] Claude manifest not at 0.2.0"
+    echo "  [FAIL] Claude manifest not at 0.2.1"
     exit 1
 fi
-if jq -e '.version == "0.2.0"' "$CODEX_PLUGIN_JSON" >/dev/null; then
-    echo "  [PASS] Codex manifest at 0.2.0"
+if jq -e '.version == "0.2.1"' "$CODEX_PLUGIN_JSON" >/dev/null; then
+    echo "  [PASS] Codex manifest at 0.2.1"
 else
-    echo "  [FAIL] Codex manifest not at 0.2.0"
+    echo "  [FAIL] Codex manifest not at 0.2.1"
     exit 1
 fi
 echo ""
 
 # Test 2: Marketplace entry bumped
-echo "Test 2: Claude marketplace frontend-design entry at 0.2.0..."
-if jq -e '.plugins[] | select(.name == "frontend-design") | .version == "0.2.0"' "$MARKETPLACE" >/dev/null; then
-    echo "  [PASS] Claude marketplace frontend-design at 0.2.0"
+echo "Test 2: Claude marketplace frontend-design entry at 0.2.1..."
+if jq -e '.plugins[] | select(.name == "frontend-design") | .version == "0.2.1"' "$MARKETPLACE" >/dev/null; then
+    echo "  [PASS] Claude marketplace frontend-design at 0.2.1"
 else
-    echo "  [FAIL] Claude marketplace frontend-design not at 0.2.0"
+    echo "  [FAIL] Claude marketplace frontend-design not at 0.2.1"
     exit 1
 fi
 echo ""
@@ -108,6 +108,20 @@ else
     echo "  [FAIL] SKILL.md is $skill_lines lines; index skill should stay <= 200"
     exit 1
 fi
+echo ""
+
+# Test 6b: Review Format section keeps the negative-example guidance. Regression
+# guard: this tail ("Wrong format" block plus "Correct format" sentence) was
+# silently dropped at port time and no assertion caught it.
+echo "Test 6b: Review Format keeps wrong/correct format guidance..."
+for phrase in 'Wrong format' 'Correct format'; do
+    if grep -qF "$phrase" "$SKILL_MD"; then
+        echo "  [PASS] SKILL.md contains '$phrase' guidance"
+    else
+        echo "  [FAIL] SKILL.md missing '$phrase' guidance (Review Format tail dropped)"
+        exit 1
+    fi
+done
 echo ""
 
 # Test 7: All seven topic references exist and are mentioned in SKILL.md

--- a/tests/unit/test-frontend-design-skill.sh
+++ b/tests/unit/test-frontend-design-skill.sh
@@ -65,7 +65,7 @@ fi
 for manifest in \
     "$REPO_ROOT/plugins/frontend-design/.claude-plugin/plugin.json" \
     "$REPO_ROOT/plugins/frontend-design/.codex-plugin/plugin.json"; do
-    if jq -e '.name == "frontend-design" and .version == "0.1.0" and .license == "MIT"' "$manifest" >/dev/null; then
+    if jq -e '.name == "frontend-design" and .version == "0.2.1" and .license == "MIT"' "$manifest" >/dev/null; then
         echo "[PASS] $manifest metadata is valid"
     else
         echo "[FAIL] $manifest metadata invalid"; exit 1


### PR DESCRIPTION
## Summary

Two `frontend-design` unit tests were failing identically on `master` (pre-existing, surfaced during the learning-plugin review). Both root-caused and fixed, plus a third silent content drop surfaced by an exhaustive audit.

- **`test-frontend-design-skill.sh` (metadata invalid):** the test pinned plugin version `0.1.0`. The plugin legitimately ships `0.2.0` (PR #42 bumped it when `emil-design-eng` was added, but never updated this one test pin: a version-bump lockstep miss). Pin corrected.
- **`test-frontend-design-emil-skill.sh` (missing `## Initial Response`):** the PR #42 port silently dropped the upstream `## Initial Response` section; the test correctly asserts it. Restored verbatim from `emilkowalski/skill@ecf66bb` (curly apostrophe normalized to straight per the file's convention). The test assertion was kept, not weakened.

## Audit findings (beyond the two reported failures)

A 5-agent audit adversarially verified both fixes and swept the repo:

- **Second silent drop, not covered by any test:** the tail of `## Review Format (Required)` (the "Wrong format (never do this)" negative example and the "Correct format" sentence), confirmed absent from the entire port. Restored, and a regression assertion (`Test 6b`) added so it cannot silently drop again.
- **Repo-wide version-pin sweep across all 11 plugins: CLEAN.** frontend-design's stale pin was the only drift; no other plugin needs correction.

Restoring skill content mandates a plugin version bump `0.2.0 -> 0.2.1` (patch; port-defect fix) across the full lockstep: both manifests, the Claude marketplace entry, the `AGENTS.md` row, and both unit-test pins. The NOTICE's "verbatim, no semantic content changed" claim is accurate again once both sections are restored.

## Scope

`frontend-design` plugin only. Independent of #59 (learning plugin), which is on a separate branch.

## Test plan

- [x] `tests/unit/test-frontend-design-skill.sh`: 15 PASS, 0 FAIL
- [x] `tests/unit/test-frontend-design-emil-skill.sh`: 33 PASS, 0 FAIL (includes new Test 6b; verified RED on pre-fix HEAD, GREEN after)
- [x] `tests/unit/test-codex-plugin-structure.sh`: OK
- [x] `tests/unit/test-skill-frontmatter-yaml.sh`: OK
- [x] No stale `0.2.0` in any frontend-design version site; all 5 lockstep sites at `0.2.1`
- [x] Emil skill subtree em-dash/en-dash scan: clean (restored separator is box-drawing U+2500, not a dash)