### PR TITLE
feat: fold Fable field-guide techniques into the skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -193,7 +193,7 @@
       "category": "Productivity",
       "interface": {
         "displayName": "Learning",
-        "shortDescription": "Get taught and quizzed to mastery"
+        "shortDescription": "Get taught and quizzed to mastery, or survey your blind spots"
       }
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "name": "workbench",
       "source": "./plugins/workbench",
       "description": "Personal Workbench skills for design and autonomous feature work.",
-      "version": "0.20.0"
+      "version": "0.21.0"
     },
     {
       "name": "terminal",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,7 +38,7 @@
       "name": "agent-system-management",
       "source": "./plugins/agent-system-management",
       "description": "Audit AGENTS.md / CLAUDE.md, capture session learnings, and create Claude Code / Codex skills.",
-      "version": "0.4.2"
+      "version": "0.4.3"
     },
     {
       "name": "workbench",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,8 +73,8 @@
     {
       "name": "learning",
       "source": "./plugins/learning",
-      "description": "Socratic teach-and-quiz skills that verify you deeply understand a session or a topic.",
-      "version": "0.1.0"
+      "description": "Socratic teach-and-quiz skills plus a pre-work blind-spot survey, so you deeply understand a session, a topic, or an unfamiliar area.",
+      "version": "0.2.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ containers/
 | `writing` | 1.7.0 | `writing`, `pyramid`, `tech-doc`, `presentations` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
 | `agent-system-management` | 0.4.2 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
-| `workbench` | 0.20.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `copilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`, `systematic-debugging`, `crafting-html`, `crafting-design-systems`, `crafting-presentations`, `exporting-decks-to-pptx`, `perfecting-presentations` |
+| `workbench` | 0.21.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `copilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`, `systematic-debugging`, `crafting-html`, `crafting-design-systems`, `crafting-presentations`, `exporting-decks-to-pptx`, `perfecting-presentations` |
 | `terminal` | 0.1.0 | `tmux` |
 | `frontend-design` | 0.2.1 | `frontend-design` (ported from Anthropic, Apache 2.0 upstream), `emil-design-eng` (ported from emilkowalski/skill, no upstream license declared) |
 | `playground` | 0.1.0 | `playground` (ported from Anthropic, Apache 2.0 upstream) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ containers/
 | `frontend-design` | 0.2.1 | `frontend-design` (ported from Anthropic, Apache 2.0 upstream), `emil-design-eng` (ported from emilkowalski/skill, no upstream license declared) |
 | `playground` | 0.1.0 | `playground` (ported from Anthropic, Apache 2.0 upstream) |
 | `databricks` | 0.3.0 | `databricks-core` (ported from databricks/databricks-agent-skills under upstream Databricks License, restricted to Databricks Services), `databricks-docs` |
-| `learning` | 0.1.0 | `quizzing-the-session`, `quizzing-a-topic` (adapted from the ThariqS "Learn Quiz" gist) |
+| `learning` | 0.2.0 | `quizzing-the-session`, `quizzing-a-topic` (adapted from the ThariqS "Learn Quiz" gist), `surveying-blind-spots` (adapted from Thariq Shihipar's blind-spot-pass technique) |
 
 ## How to Develop a New Skill
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ containers/
 | `research` | 2.1.1 | `research` (multi-agent pipeline with review gates) |
 | `writing` | 1.7.0 | `writing`, `pyramid`, `tech-doc`, `presentations` |
 | `runtime-bridge` | 0.1.0 | `claude-codex-bridge` |
-| `agent-system-management` | 0.4.2 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
+| `agent-system-management` | 0.4.3 | `improving-instructions`, `capturing-session-learnings`, `creating-skills` |
 | `workbench` | 0.21.0 | `brainstorming`, `writing-spec`, `writing-plans`, `visualizing-options`, `using-workbench`, `terse-mode`, `autopilot`, `copilot`, `verification-before-completion`, `test-driven-development`, `dispatching-parallel-agents`, `subagent-driven-development`, `systematic-debugging`, `crafting-html`, `crafting-design-systems`, `crafting-presentations`, `exporting-decks-to-pptx`, `perfecting-presentations` |
 | `terminal` | 0.1.0 | `tmux` |
 | `frontend-design` | 0.2.1 | `frontend-design` (ported from Anthropic, Apache 2.0 upstream), `emil-design-eng` (ported from emilkowalski/skill, no upstream license declared) |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Bundles 12 plugins across Atlassian, Google Workspace, Databricks, agent-system 
 | `databricks-docs` | `databricks` | Live `docs.databricks.com` lookups for product-surface questions |
 | `quizzing-the-session` | `learning` | Get taught and quizzed on the current session's work until you demonstrably understand the problem, solution, and impact |
 | `quizzing-a-topic` | `learning` | Get taught and quizzed on any topic or theme you name until you demonstrably understand it |
+| `surveying-blind-spots` | `learning` | Pre-work blind-spot pass over an unfamiliar codebase area or field, surfacing unknown unknowns, gotchas, and better prompts |
 
 Skills are invoked from the host agent (Claude Code or Codex) using the fully qualified form `/<plugin>:<skill>`, for example `/atlassian:jira` or `/workbench:autopilot`.
 
@@ -233,11 +234,12 @@ Two Databricks skills. `databricks-core` is a verbatim port from [databricks/dat
 
 ### learning
 
-Socratic teach-and-quiz skills that verify you deeply understand something. An original adaptation of Thariq Shihipar's "Learn Quiz" gist (see `plugins/learning/README.md` for attribution).
+Skills that teach the human: Socratic teach-and-quiz loops plus a pre-work blind-spot survey. An original adaptation of Thariq Shihipar's "Learn Quiz" gist and his AI Engineer talk techniques (see `plugins/learning/README.md` for attribution).
 
 **Skills:**
-- `/learning:quizzing-the-session`: Build a problem/solution/impact checklist from the current session and recent git activity, then teach and quiz you item by item to mastery.
+- `/learning:quizzing-the-session`: Build a problem/solution/impact checklist from the current session and recent git activity, then teach and quiz you item by item to mastery. Also fits right before a PR or merge, to confirm you can represent the work in review.
 - `/learning:quizzing-a-topic`: The same teaching engine pointed at any topic or theme you name, grounded in repo files when the topic is local code.
+- `/learning:surveying-blind-spots`: A pre-work blind-spot pass over a codebase area or field you do not know. Surfaces unknown unknowns, gotchas, and dead ends, then hands you rewritten prompts. A briefing, not a quiz.
 
 ---
 

--- a/plugins/agent-system-management/.claude-plugin/plugin.json
+++ b/plugins/agent-system-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-system-management",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Audit AGENTS.md / CLAUDE.md, capture session learnings, and create Claude Code / Codex skills.",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/agent-system-management/.codex-plugin/plugin.json
+++ b/plugins/agent-system-management/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-system-management",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Audit AGENTS.md / CLAUDE.md, capture session learnings, and create Claude Code / Codex skills.",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/agent-system-management/skills/capturing-session-learnings/SKILL.md
+++ b/plugins/agent-system-management/skills/capturing-session-learnings/SKILL.md
@@ -74,6 +74,8 @@ Avoid:
 - Obvious information
 - One-off fixes unlikely to recur
 
+When a learning takes the form of a prohibition, capture the reason or the preferred alternative in the same line. A bare "do not X" does not generalize to the next session; "prefer Y over X because Z" does.
+
 ## Step 5: Show proposed changes
 
 For each addition:

--- a/plugins/agent-system-management/skills/improving-instructions/SKILL.md
+++ b/plugins/agent-system-management/skills/improving-instructions/SKILL.md
@@ -179,6 +179,8 @@ See [references/update-guidelines.md](references/update-guidelines.md) for full 
 6. **Undocumented gotchas**: non-obvious patterns not captured
 7. **Scope mismatch**: project-specific rules in the user-global file (or vice versa)
 8. **Duplicate rules**: same rule stated in both project and user-global file
+9. **Bare prohibitions**: "do not X" rules with no reason or alternative attached; propose restating as intent plus the preferred alternative
+10. **Constraint accretion**: defensive rules whose failure mode no longer occurs; propose deletion when nobody can name what the rule prevents
 
 ## User Tips to Share
 

--- a/plugins/agent-system-management/skills/improving-instructions/references/quality-criteria.md
+++ b/plugins/agent-system-management/skills/improving-instructions/references/quality-criteria.md
@@ -107,3 +107,5 @@
 - Generic advice not specific to the project
 - "TODO" items never completed
 - Duplicate info across multiple CLAUDE.md files
+- Bare prohibitions: "do not X" rules with no stated reason and no preferred alternative. The agent cannot generalize from a ban alone; flag for rewrite as intent plus alternative. Keep the hard-ban form only where the action is destructive, irreversible, or security-sensitive.
+- Constraint accretion: defensive rules guarding against failure modes nobody has observed recently. If neither the file nor the user can name the concrete failure a rule prevents, propose deleting it; a shorter file of reasons outperforms a longer file of bans.

--- a/plugins/learning/.claude-plugin/plugin.json
+++ b/plugins/learning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Socratic teach-and-quiz skills that verify you deeply understand a session or a topic.",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/learning/.codex-plugin/plugin.json
+++ b/plugins/learning/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Socratic teach-and-quiz skills that verify you deeply understand a session or a topic.",
   "author": { "name": "Pascal Göllner" },
   "license": "MIT",

--- a/plugins/learning/README.md
+++ b/plugins/learning/README.md
@@ -1,14 +1,15 @@
 # Learning
 
-Socratic teach-and-quiz skills that verify you deeply understand something, not just nod along.
+Skills that teach the human: Socratic teach-and-quiz loops that verify you deeply understand something, plus a pre-work blind-spot survey that maps what you do not know yet.
 
 ## Skills
 
-- `/learning:quizzing-the-session`: Build a problem/solution/impact checklist from the current session and recent git activity, then teach and quiz you to mastery.
+- `/learning:quizzing-the-session`: Build a problem/solution/impact checklist from the current session and recent git activity, then teach and quiz you to mastery. Also fits right before a PR or merge, to confirm you can represent the work in review.
 - `/learning:quizzing-a-topic`: The same teaching engine pointed at any topic or theme you name.
+- `/learning:surveying-blind-spots`: A pre-work blind-spot pass over a codebase area or field you do not know. Surfaces unknown unknowns, gotchas, and dead ends, then hands you rewritten prompts that bake in what it found. A briefing, not a quiz.
 
-Both have the assistant assess what you already know, fill the gaps, and quiz you item by item (multiple-choice via AskUserQuestion, with the correct option shuffled and hidden until you submit). The session never finishes until you have demonstrated you understand every item.
+The two quizzing skills have the assistant assess what you already know, fill the gaps, and quiz you item by item (multiple-choice via AskUserQuestion, with the correct option shuffled and hidden until you submit). The session never finishes until you have demonstrated you understand every item.
 
 ## Inspiration
 
-These skills are an original adaptation, "stolen like an artist", of Thariq Shihipar's "Learn Quiz" gist: <https://gist.github.com/ThariqS/1389dcdff9eba4789887a2211370f06b>. No upstream text is vendored verbatim; the concept (a teacher that quizzes incrementally to confirm deep understanding) is reimplemented in this repo's conventions. Original work is MIT licensed.
+These skills are an original adaptation, "stolen like an artist", of Thariq Shihipar's work: the two quizzing skills from his "Learn Quiz" gist (<https://gist.github.com/ThariqS/1389dcdff9eba4789887a2211370f06b>), and the blind-spot pass from the "find your unknowns" techniques in his AI Engineer talk on working with new model generations. No upstream text is vendored verbatim; the concepts are reimplemented in this repo's conventions. Original work is MIT licensed.

--- a/plugins/learning/skills/quizzing-a-topic/SKILL.md
+++ b/plugins/learning/skills/quizzing-a-topic/SKILL.md
@@ -15,6 +15,7 @@ You are a sharp, patient teacher. Your goal is that by the end the user can expl
 ## When NOT to invoke
 
 - The user wants to be quizzed on the work from the current session ("quiz me on what we just did"). Use `learning:quizzing-the-session` instead.
+- The user wants a pre-work survey of their unknown unknowns without a quiz loop ("do a blind spot pass"). Use `learning:surveying-blind-spots` instead.
 - The goal is producing study notes or a document rather than an interactive tutoring loop.
 
 ## Pick and scope the topic
@@ -52,6 +53,7 @@ Run this loop, one checklist item at a time, top to bottom:
 - Reveal the correct answer and the explanation only in the message **after** the user submits, never before.
 - For "restate your understanding" and other open-ended prompts, ask in prose. `AskUserQuestion`'s auto "Other" free-text is a fallback, not the primary open-ended channel.
 - Quiz incrementally: one item at a time, woven into the loop, not batched at the end.
+- When an answer key is enumerable or computable (a list, a count, a flag name, version-specific behavior), derive and verify it before asking: write a quick script, run the command, or read the authoritative doc or repo file. Do not quiz from recall on facts a tool call can settle; a wrong answer key mis-teaches with authority.
 - Escalate difficulty **within each item** before marking it mastered: start with recall, move to application, then to an edge case or "what would break if" question. Only when the user clears the edge-case rung is the item mastered.
 
 ## Depth levels

--- a/plugins/learning/skills/quizzing-the-session/SKILL.md
+++ b/plugins/learning/skills/quizzing-the-session/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quizzing-the-session
-description: Use when the user wants to be taught and quizzed on the work from the current session, what was just built, decided, debugged, or changed, to verify they deeply understand it. Not for updating agent instruction files; that is capturing-session-learnings.
+description: Use when the user wants to be taught and quizzed on the work from the current session, what was just built, decided, debugged, or changed, to verify they deeply understand it. Also use right before opening a PR or merging, when the user wants to confirm they can represent the work in review. Not for updating agent instruction files; that is capturing-session-learnings.
 ---
 
 # Quizzing the Session
@@ -11,6 +11,7 @@ You are a sharp, patient teacher. Your goal is that by the end the user can expl
 
 - "Quiz me on what we just did." "Make sure I actually understand this change." "Test me on the session."
 - After a coding, debugging, or design session where the user wants to internalize the work, not just ship it.
+- Right before opening a PR or merging ("Quiz me before I open this PR", "quiz me so I can explain this change to my reviewer").
 
 ## When NOT to invoke
 
@@ -32,6 +33,8 @@ Organize the must-understand items into three pillars (the gist's structure, ada
 3. **The broader context**: why this matters, what it touches downstream, what could break or change next.
 
 Write the checklist to the running doc (see below) before teaching. Each pillar gets its own checkboxes.
+
+When the user invoked this right before a PR or merge, weight the checklist toward what a reviewer would probe first, starting with the riskiest hunk in the diff.
 
 ## The teaching loop
 

--- a/plugins/learning/skills/surveying-blind-spots/SKILL.md
+++ b/plugins/learning/skills/surveying-blind-spots/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: surveying-blind-spots
+description: Use when the user is about to start work in a codebase area or field they do not know well and wants a blind-spot pass, a survey of their unknown unknowns, gotchas, and dead ends, before they write a prompt or plan. For example "I know nothing about the auth module, find my blind spots" or "what don't I know about color grading". Not for tutoring to mastery; that is quizzing-a-topic.
+---
+
+# Surveying Blind Spots
+
+The user cannot ask about what they cannot name. Explore the target on their behalf, surface the unknown unknowns, and leave them able to prompt and plan with eyes open. This is a briefing, not a tutoring loop: do not quiz, do not gate on mastery, do not lecture the whole field.
+
+## When to invoke
+
+- "Do a blind spot pass on X." "I'm new to this module, what don't I know?" "What are my unknown unknowns about Y?" "Help me prompt better about Z."
+
+## When NOT to invoke
+
+- The user wants to be taught and quizzed to mastery. Use `learning:quizzing-a-topic`.
+- The user is ready to converge a design through Q and A. Use `workbench:brainstorming`; this skill feeds it.
+- The user wants a cited multi-source report. Use `research:research`.
+
+## Scope the pass
+
+- Ask at most one clarifying question, and only if the target is unbounded. Starting fast beats interrogating.
+- The user often names where context lives (a module path, a branch, a doc folder, an exported thread). Follow those pointers before anything else.
+
+## Codebase pass
+
+When the target maps to a repo:
+
+1. Dispatch a cost-efficient subagent (Claude Code: `Explore` agent type; Codex: read-only research agent equivalent; inline if dispatch is unavailable) over the named area: entry points, config surface, and the two or three files everything else imports.
+2. Mine the history for pain: `git log --oneline -30 -- <area>`, then read commits whose messages contain fix, revert, workaround, or hack. Repeated churn on one file marks a dead end someone already hit.
+3. Read the area's tests and its TODO, FIXME, and HACK comments; they encode the gotchas the authors thought worth pinning.
+4. Collect conventions the user would violate by default: error handling shape, layering rules, naming, test layout.
+
+## Field pass
+
+When the target is a domain rather than code:
+
+1. Lay out the map of the field from your own knowledge: core concepts, the vocabulary the user needs to search well, the standard tools, and the classic beginner traps.
+2. Mark every claim that is version-sensitive or time-sensitive and verify those with web search when available instead of asserting from memory.
+
+## The briefing
+
+Deliver in chat, ordered by how likely each item is to burn the user:
+
+1. Unknown unknowns: things the user showed no sign of knowing, with one line each on why it matters.
+2. Gotchas and dead ends: each with its evidence (a commit, a comment, a known failure mode).
+3. Vocabulary: the terms the user needs to prompt and search effectively.
+4. Better prompts: two or three rewritten versions of the user's stated goal that bake in what the pass found, ready to paste into a fresh session.
+5. Open questions: what the pass could not resolve, and where the answer likely lives.
+
+Keep the briefing scannable. Close by offering, not forcing, the follow-ups: `learning:quizzing-a-topic` to verify understanding, or `workbench:brainstorming` to start converging a design.

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/.codex-plugin/plugin.json
+++ b/plugins/workbench/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workbench",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Personal Workbench skills for design and autonomous feature work.",
   "author": {
     "name": "Pascal Göllner"

--- a/plugins/workbench/skills/autopilot/SKILL.md
+++ b/plugins/workbench/skills/autopilot/SKILL.md
@@ -38,6 +38,16 @@ Autopilot maintains a visible task list for the whole run and keeps it current. 
 - Keep the task list aligned with the committed or scratch plan. If the plan changes, update the task list in the same turn before executing the changed work.
 - In the end-of-turn summary, mention any task-list item that remains incomplete and why.
 
+## Deviation Log
+
+Autonomy means deciding without pausing, not deciding without a trace. Keep a per-run deviation log so the user can see afterward where the run departed from the spec, plan, or profile.
+
+- Start the log fresh at the beginning of every run: `mkdir -p /tmp/<project-name>-autopilot && rm -f /tmp/<project-name>-autopilot/deviations.md`.
+- When you hit a decision point the plan, spec, or profile did not specify, or where reality contradicts them (an API that does not behave as the spec assumed, a missing file, a wrong test command), decide per the fork rule in Tone and reporting, then append one entry before continuing: the step you were in, what was unspecified or wrong, what you decided, and one line of reasoning.
+- Log every departure from the committed plan: a task executed differently than written, a task skipped, or a task added. Also log any deviation a subagent reports in its return (a `DONE_WITH_CONCERNS` status or a deviations block).
+- Do not log routine choices the plan anticipated (variable names, commit wording). The log records forks, not noise.
+- The log lives in scratch and is never committed.
+
 ## Non-negotiables
 
 See `references/invariants.md` for the full list. Summary:
@@ -292,5 +302,5 @@ If the user explicitly says "don't merge" before or during the run, override `au
 ## Tone and reporting
 
 - Terse between tool calls. The user sees the PR diff; they don't need narration.
-- End-of-turn summary: PR URL, one sentence on what changed, next step (usually "review when ready" or, for automerge, "merged at <commit>"). Also list any required skill that was unavailable in the runtime and therefore skipped.
+- End-of-turn summary: PR URL, one sentence on what changed, next step (usually "review when ready" or, for automerge, "merged at <commit>"). Also list any required skill that was unavailable in the runtime and therefore skipped. Also list every deviation-log entry, one line each, or state that there were no deviations; a deviation that changed user-visible behavior also belongs in the PR body's `## Summary`.
 - If you hit an unexpected fork in the road that truly needs the user (not a routine choice), stop and ask. But bias strongly toward deciding yourself; that is the point of autopilot.

--- a/plugins/workbench/skills/brainstorming/SKILL.md
+++ b/plugins/workbench/skills/brainstorming/SKILL.md
@@ -36,6 +36,16 @@ Two minds building together share an invisible theory of the system: the design 
 
 Treat the design as a tree. The root is "what are we building, and why." Branches resolve to dependent decisions: which approach, which boundaries, which interfaces, which failure modes. Leaves are the decisions themselves. Pick one branch, follow every dependency to a decision, only then return to the next branch. Do not breadth-first a checklist of section headings.
 
+**Order branches by decision leverage.**
+
+When choosing which branch to walk next, pick the one whose answers could invalidate the most other decisions: architecture and approach first, then boundaries and interfaces, then failure modes, then cosmetic or easily reversed details last. One question that could change the architecture is worth more early than ten leaf questions answered under an architecture that might not survive. If a later answer reveals that an unwalked branch invalidates decisions already made, jump to that branch immediately and revisit the affected leaves afterward.
+
+**Ask for reference artifacts early.**
+
+Within the first few questions, ask once whether the user can point at reference artifacts: existing code in this or another repo (even another language), an HTML mockup, a similar feature in another system, an API to mirror. If they name one, read it completely before the next question, then play back what you took from it: what to imitate, what to diverge from, what to omit. Treat the artifact as the answer to every design-tree branch it settles and spend the remaining questions only on the deltas. Record each artifact's path or URL in the Q and A record so the brainstorm summary and the downstream spec can cite it.
+
+In autonomous runs where the user is not present (for example inside `workbench:autopilot`), substitute a search for the ask: extend the checklist-item-1 exploration subagent's prompt with "also report the closest existing implementation of anything similar in this repo, with paths", and read what it finds before self-answering.
+
 **Take an adversarial posture.**
 
 Probe for unstated assumptions, latent constraints, and edge cases the user has not considered. When the user gives a short answer, ask the obvious next question even when the answer feels implied. Treat the user as the source of truth about what they want and treat yourself as the source of skeptical pressure on whether they have said it clearly.
@@ -84,6 +94,7 @@ digraph brainstorming {
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems, flag this immediately. Do not spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects. Each sub-project then gets its own brainstorm and spec cycle.
 - For appropriately scoped projects, ask questions one at a time.
+- Ask once, early, for reference artifacts; a named artifact replaces prose answers for every branch it settles. See **Ask for reference artifacts early** above.
 - Prefer multiple choice questions when possible.
 - One question per message.
 - Focus on understanding: purpose, constraints, success criteria.
@@ -92,6 +103,8 @@ digraph brainstorming {
 **Exploring approaches:**
 
 - Propose 2-3 different approaches with trade-offs.
+- Before presenting two desirable properties as an either/or, name the constraint that forces the choice: a design-level mutual exclusion, an external dependency, or a hard runtime, budget, or compatibility limit. Implementation effort alone is not a forcing constraint; if you cannot name one, the trade-off is assumed, not real.
+- When the options differ only in implementation effort, include the combined approach as one of the 2-3, priced concretely (files touched, tests added, latency, maintenance surface) so the user can decline it knowingly. YAGNI still governs unrequested features; this rule protects scope the user asked for from being cut on an assumed cost.
 - Lead with your recommendation and explain why.
 
 **Presenting the design:**
@@ -109,6 +122,7 @@ digraph brainstorming {
 **Working in existing codebases:**
 
 - Delegate exploration of the area you are touching to a cost-efficient subagent. Follow the returned conventions.
+- If the user says they do not know the area, relay the survey's conventions, gotchas, and dead ends to them before the first design question, so their answers are informed. For a standalone pre-work pass outside a design conversation, see `learning:surveying-blind-spots`.
 - Where existing code has problems that affect the work, include targeted improvements as part of the design.
 - Do not propose unrelated refactoring.
 
@@ -117,6 +131,8 @@ digraph brainstorming {
 If the conversation will involve visual content (mockups, layouts, diagrams), mention `workbench:visualizing-options` in its own message before asking the next question. The user opts in by acknowledging. That skill owns the browser companion; this skill stays in the terminal.
 
 The offer message should contain ONLY the pointer; do not combine it with clarifying questions.
+
+If the user stalls on a visual question ("I don't know", "whatever looks good"), stop rephrasing it in words. Use `workbench:visualizing-options` to render 3-4 deliberately divergent directions the user can react to instead of describe. If the companion is not yet running, make the offer at that moment (same rule: own message, pointer only) and render once the user opts in.
 
 ## Handoff
 
@@ -129,6 +145,7 @@ The conversation itself is the handoff payload; the summary file is a record, no
 - One question at a time.
 - Multiple choice preferred.
 - Depth-first grilling: walk the design tree, do not breadth-first a checklist.
+- Highest-leverage branches first: architecture-changing questions before detail questions.
 - YAGNI ruthlessly.
 - Explore alternatives.
 - Incremental validation.

--- a/plugins/workbench/skills/copilot/SKILL.md
+++ b/plugins/workbench/skills/copilot/SKILL.md
@@ -40,6 +40,17 @@ Copilot maintains a visible task list for the whole run and keeps it current. Th
 - Keep the task list aligned with the committed or scratch plan. If the plan changes, update the task list in the same turn before executing the changed work.
 - In the end-of-turn summary, mention any task-list item that remains incomplete and why.
 
+## Deviation Log
+
+The user personally approved the design at the two gates; a departure from the approved spec or committed plan during the autonomous steps (1 and 4 through 9) is recorded, never silently absorbed. Keep a per-run deviation log.
+
+- Start the log fresh at the beginning of every run: `mkdir -p /tmp/<project-name>-autopilot && rm -f /tmp/<project-name>-autopilot/deviations.md`.
+- When you hit a decision point the spec or plan did not specify, or where reality contradicts them (an API that does not behave as the spec assumed, a missing file, a wrong test command), decide it, then append one entry before continuing: the step you were in, what was unspecified or wrong, what you decided, and one line of reasoning.
+- Log every departure from the committed plan: a task executed differently than written, a task skipped, or a task added. Also log any deviation a subagent reports in its return (a `DONE_WITH_CONCERNS` status or a deviations block).
+- Decisions the user made at the two human gates (brainstorm, spec approval) are user decisions, not deviations; do not log them. If a deviation would invalidate a decision the user made at a gate, stop and ask before proceeding; do not log-and-continue past a human decision.
+- Do not log routine choices the plan anticipated (variable names, commit wording). The log records forks, not noise.
+- The log lives in scratch and is never committed.
+
 ## Non-negotiables
 
 See `../autopilot/references/invariants.md` for the full list. Summary:
@@ -273,5 +284,5 @@ If the user explicitly says "don't merge" before or during the run, override `au
 
 - Terse between tool calls. The user sees the PR diff; they don't need narration.
 - Copilot pauses for the user at the two design gates (step 2 brainstorm and step 3 spec). At those gates, slow down and let the user drive. Everywhere else, keep moving.
-- End-of-turn summary: PR URL, one sentence on what changed, next step (usually "review when ready" or, for automerge, "merged at <commit>"). Also list any required skill that was unavailable in the runtime and therefore skipped.
+- End-of-turn summary: PR URL, one sentence on what changed, next step (usually "review when ready" or, for automerge, "merged at <commit>"). Also list any required skill that was unavailable in the runtime and therefore skipped. Also list every deviation-log entry, one line each, or state that there were no deviations; a deviation that changed user-visible behavior also belongs in the PR body's `## Summary`.
 - Copilot pauses only at the two human gates (brainstorm and spec) and at a true fork it cannot resolve; everywhere else it decides for itself, that is the point of copilot.

--- a/plugins/workbench/skills/subagent-driven-development/SKILL.md
+++ b/plugins/workbench/skills/subagent-driven-development/SKILL.md
@@ -29,11 +29,12 @@ For each plan task:
 3. Include acceptance criteria and verification commands.
 4. Tell the agent it is not alone in the codebase and must not revert edits made by others.
 5. Wait for the implementation agent to return.
-6. Run the spec compliance reviewer.
-7. Fix any spec gaps and re-review.
-8. Run the code quality reviewer.
-9. Fix any quality issues and re-review.
-10. Mark the task complete only after both review gates pass.
+6. Record any deviations the agent returned in a running list for the whole plan execution.
+7. Run the spec compliance reviewer.
+8. Fix any spec gaps and re-review.
+9. Run the code quality reviewer.
+10. Fix any quality issues and re-review.
+11. Mark the task complete only after both review gates pass.
 
 ## Two review gates
 
@@ -76,6 +77,7 @@ Return:
 - Files changed.
 - Verification commands and results.
 - Concerns, if any.
+- Deviations: each decision point the task did not specify and how you resolved it, or none.
 ```
 
 ## Handling Agent Status
@@ -108,4 +110,5 @@ After all tasks pass both review gates:
 
 - Run the full relevant verification set.
 - Inspect `git status` and `git diff`.
+- Report the collected deviations from all tasks to the user, or state that there were none.
 - Use `workbench:verification-before-completion` before claiming the branch is complete or ready.

--- a/plugins/workbench/skills/visualizing-options/SKILL.md
+++ b/plugins/workbench/skills/visualizing-options/SKILL.md
@@ -22,6 +22,12 @@ Use the terminal otherwise: requirements, scope, conceptual A/B/C choices, trade
 
 A question about a UI topic is not automatically a visual question. "What kind of wizard do you want?" is conceptual. "Which of these wizard layouts feels right?" is visual.
 
+## Divergent Directions
+
+When the user cannot describe what they want in words (signals: "make it look nice", "I have no visual taste", "I'll know it when I see it", repeated "I don't know" on visual questions), stop asking and show. Render 3-4 deliberately divergent directions on one screen. Each option commits to a different aesthetic pole (for example minimal, illustrated, playful, editorial); never show variations of one theme that differ only in accent color or spacing. Label each direction and state its intent in one line, so the user reacts to real spread instead of imagining alternatives.
+
+After the user reacts, converge: take the chosen direction (or the elements they liked across directions) and iterate within-direction variations on the next screen.
+
 ## Quick Start
 
 ```bash

--- a/plugins/workbench/skills/visualizing-options/visual-companion.md
+++ b/plugins/workbench/skills/visualizing-options/visual-companion.md
@@ -263,6 +263,7 @@ If `$STATE_DIR/events` doesn't exist, the user didn't interact with the browser 
 - **Explain the question on each page** — "Which layout feels more professional?" not just "Pick one"
 - **Iterate before advancing** — if feedback changes current screen, write a new version
 - **2-4 options max** per screen
+- **Diverge before you converge**: when the user cannot articulate taste, make the options wildly different aesthetic directions, not near-duplicates; narrow to within-direction variations only after the user reacts
 - **Use real content when it matters** — for a photography portfolio, use actual images (Unsplash). Placeholder content obscures design issues.
 - **Keep mockups simple** — focus on layout and structure, not pixel-perfect design
 

--- a/plugins/workbench/skills/writing-spec/SKILL.md
+++ b/plugins/workbench/skills/writing-spec/SKILL.md
@@ -42,8 +42,9 @@ Cover, scaling each section to its complexity:
 - Solution overview.
 - User stories (numbered).
 - Implementation decisions (modules, interfaces, file layout, no code snippets).
+- Reference artifacts, only if the discussion anchored on any: path or URL of each (existing code, mockup, similar system), plus one line each on what to imitate and what to diverge from.
 - Testing decisions.
-- Out of scope.
+- Out of scope. Give every exclusion a one-line reason naming what forces it out: a conflicting requirement, an external dependency, or a boundary into a separate spec. If the only reason is implementation effort, write "cut for effort" explicitly so the user can pull the item back in at the approval gate instead of assuming it was impossible.
 - Risks.
 
 Use `elements-of-style:writing-clearly-and-concisely` if available.

--- a/tests/skill-triggering/prompts/learning-blind-spot-pass.txt
+++ b/tests/skill-triggering/prompts/learning-blind-spot-pass.txt
@@ -1,0 +1,1 @@
+I'm about to start working on the auth module and I know nothing about it. Do a blind spot pass so I find my unknown unknowns before I write a prompt.

--- a/tests/skill-triggering/prompts/learning-quiz-before-pr.txt
+++ b/tests/skill-triggering/prompts/learning-quiz-before-pr.txt
@@ -1,0 +1,1 @@
+I am about to merge this branch. Quiz me first so I can explain the change to my reviewer.

--- a/tests/unit/test-creating-skills-skill.sh
+++ b/tests/unit/test-creating-skills-skill.sh
@@ -2,7 +2,7 @@
 # Test: agent-system-management:creating-skills skill structure
 # Verifies SKILL.md exists, frontmatter is valid, all five mode sections are present,
 # four reference files plus the templates/ subdirectory exist and are non-empty,
-# plugin manifests are at 0.4.2, and the skill mentions marketplace detection plus
+# plugin manifests are at 0.4.3, and the skill mentions marketplace detection plus
 # the three SKILL.md template types.
 set -euo pipefail
 
@@ -17,8 +17,8 @@ SKILL_MD="$SKILL_DIR/SKILL.md"
 echo "=== Test: agent-system-management:creating-skills skill structure ==="
 echo ""
 
-# Test 1: Plugin manifests exist, parse, and are at 0.4.2
-echo "Test 1: Plugin manifests at 0.4.2..."
+# Test 1: Plugin manifests exist, parse, and are at 0.4.3
+echo "Test 1: Plugin manifests at 0.4.3..."
 for manifest in .claude-plugin/plugin.json .codex-plugin/plugin.json; do
     f="$PLUGIN_ROOT/$manifest"
     if [ ! -f "$f" ]; then
@@ -30,11 +30,11 @@ for manifest in .claude-plugin/plugin.json .codex-plugin/plugin.json; do
         exit 1
     fi
     version=$(jq -r .version "$f")
-    if [ "$version" != "0.4.2" ]; then
-        echo "  [FAIL] $manifest version is $version, expected 0.4.2"
+    if [ "$version" != "0.4.3" ]; then
+        echo "  [FAIL] $manifest version is $version, expected 0.4.3"
         exit 1
     fi
-    echo "  [PASS] $manifest exists, parses, version 0.4.2"
+    echo "  [PASS] $manifest exists, parses, version 0.4.3"
 done
 echo ""
 
@@ -230,10 +230,10 @@ else
     echo "  [FAIL] AGENTS.md missing plugin version bump rule"
     exit 1
 fi
-if jq -e '.plugins[] | select(.name == "agent-system-management") | .version == "0.4.2"' "$REPO_ROOT/.claude-plugin/marketplace.json" >/dev/null; then
-    echo "  [PASS] Claude marketplace agent-system-management at 0.4.2"
+if jq -e '.plugins[] | select(.name == "agent-system-management") | .version == "0.4.3"' "$REPO_ROOT/.claude-plugin/marketplace.json" >/dev/null; then
+    echo "  [PASS] Claude marketplace agent-system-management at 0.4.3"
 else
-    echo "  [FAIL] Claude marketplace agent-system-management not at 0.4.2"
+    echo "  [FAIL] Claude marketplace agent-system-management not at 0.4.3"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-learning-quizzing-a-topic-skill.sh
+++ b/tests/unit/test-learning-quizzing-a-topic-skill.sh
@@ -44,12 +44,12 @@ else
 fi
 echo ""
 
-# Test 3: both plugin manifests pin version 0.1.0
-echo "Test 3: plugin manifests at 0.1.0..."
-if jq -e '.version == "0.1.0"' "$CCM" >/dev/null && jq -e '.version == "0.1.0"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.1.0"
+# Test 3: both plugin manifests pin version 0.2.0
+echo "Test 3: plugin manifests at 0.2.0..."
+if jq -e '.version == "0.2.0"' "$CCM" >/dev/null && jq -e '.version == "0.2.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.2.0"
 else
-    echo "  [FAIL] plugin manifests not at 0.1.0"
+    echo "  [FAIL] plugin manifests not at 0.2.0"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-learning-quizzing-the-session-skill.sh
+++ b/tests/unit/test-learning-quizzing-the-session-skill.sh
@@ -43,12 +43,12 @@ else
 fi
 echo ""
 
-# Test 3: both plugin manifests pin version 0.1.0
-echo "Test 3: plugin manifests at 0.1.0..."
-if jq -e '.version == "0.1.0"' "$CCM" >/dev/null && jq -e '.version == "0.1.0"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.1.0"
+# Test 3: both plugin manifests pin version 0.2.0
+echo "Test 3: plugin manifests at 0.2.0..."
+if jq -e '.version == "0.2.0"' "$CCM" >/dev/null && jq -e '.version == "0.2.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.2.0"
 else
-    echo "  [FAIL] plugin manifests not at 0.1.0"
+    echo "  [FAIL] plugin manifests not at 0.2.0"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-learning-surveying-blind-spots-skill.sh
+++ b/tests/unit/test-learning-surveying-blind-spots-skill.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Test: learning:surveying-blind-spots skill structure
+# Verifies SKILL.md exists with correct frontmatter, the plugin manifests are at
+# the current learning version, the body carries the two pass shapes (codebase,
+# field) and the briefing deliverable with rewritten prompts, the sibling
+# routing lines are in place, and the subtree has no em-dashes/en-dashes.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/../test-helpers.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/learning/skills/surveying-blind-spots"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+SIBLING_MD="$REPO_ROOT/plugins/learning/skills/quizzing-a-topic/SKILL.md"
+CCM="$REPO_ROOT/plugins/learning/.claude-plugin/plugin.json"
+CXM="$REPO_ROOT/plugins/learning/.codex-plugin/plugin.json"
+
+echo "=== Test: learning:surveying-blind-spots skill structure ==="
+echo ""
+
+# Test 1: SKILL.md exists with frontmatter
+echo "Test 1: SKILL.md exists with frontmatter..."
+if [ -s "$SKILL_MD" ]; then
+    if head -1 "$SKILL_MD" | grep -q '^---$'; then
+        echo "  [PASS] SKILL.md exists with frontmatter"
+    else
+        echo "  [FAIL] SKILL.md missing frontmatter"
+        exit 1
+    fi
+else
+    echo "  [FAIL] SKILL.md missing or empty"
+    exit 1
+fi
+echo ""
+
+# Test 2: frontmatter name is surveying-blind-spots
+echo "Test 2: frontmatter name..."
+name=$(awk -F': *' '/^name:/{print $2; exit}' "$SKILL_MD")
+if [ "$name" = "surveying-blind-spots" ]; then
+    echo "  [PASS] name is surveying-blind-spots"
+else
+    echo "  [FAIL] name is '$name' (expected surveying-blind-spots)"
+    exit 1
+fi
+echo ""
+
+# Test 3: both plugin manifests pin version 0.2.0
+echo "Test 3: plugin manifests at 0.2.0..."
+if jq -e '.version == "0.2.0"' "$CCM" >/dev/null && jq -e '.version == "0.2.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.2.0"
+else
+    echo "  [FAIL] plugin manifests not at 0.2.0"
+    exit 1
+fi
+echo ""
+
+# Test 4: body carries the pass shapes and the briefing deliverable
+echo "Test 4: body carries pass shapes + briefing..."
+for term in 'Codebase pass' 'Field pass' 'briefing' 'unknown unknowns' 'git log' 'Better prompts'; do
+    if grep -qF "$term" "$SKILL_MD"; then
+        echo "  [PASS] SKILL.md mentions $term"
+    else
+        echo "  [FAIL] SKILL.md missing $term"
+        exit 1
+    fi
+done
+echo ""
+
+# Test 5: no quiz loop; briefing not tutoring
+echo "Test 5: routes tutoring away instead of quizzing..."
+if grep -qF 'learning:quizzing-a-topic' "$SKILL_MD"; then
+    echo "  [PASS] SKILL.md routes mastery tutoring to quizzing-a-topic"
+else
+    echo "  [FAIL] SKILL.md missing quizzing-a-topic routing"
+    exit 1
+fi
+if grep -qF 'do not quiz' "$SKILL_MD"; then
+    echo "  [PASS] SKILL.md forbids the quiz loop"
+else
+    echo "  [FAIL] SKILL.md missing the no-quiz framing"
+    exit 1
+fi
+echo ""
+
+# Test 6: sibling quizzing-a-topic routes blind-spot prompts here
+echo "Test 6: sibling routing line..."
+if grep -qF 'learning:surveying-blind-spots' "$SIBLING_MD"; then
+    echo "  [PASS] quizzing-a-topic routes blind-spot passes here"
+else
+    echo "  [FAIL] quizzing-a-topic missing surveying-blind-spots routing"
+    exit 1
+fi
+echo ""
+
+# Test 7: no em-dashes or en-dashes anywhere in the skill subtree
+echo "Test 7: no em-dashes/en-dashes in subtree..."
+if grep -rqP '[\x{2014}\x{2013}]' "$SKILL_DIR"; then
+    echo "  [FAIL] em-dash or en-dash found in $SKILL_DIR"
+    grep -rnP '[\x{2014}\x{2013}]' "$SKILL_DIR" | sed 's/^/    /'
+    exit 1
+else
+    echo "  [PASS] no em-dashes/en-dashes"
+fi
+echo ""
+
+echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-autopilot-skill.sh
+++ b/tests/unit/test-workbench-autopilot-skill.sh
@@ -169,25 +169,25 @@ for term in 'Task List Discipline' 'TodoWrite' 'update_plan' 'exactly one item `
 done
 echo ""
 
-# Test 12: Plugin manifests at 0.20.0
-echo "Test 12: Plugin manifests at 0.20.0..."
+# Test 12: Plugin manifests at 0.21.0
+echo "Test 12: Plugin manifests at 0.21.0..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null; then
-    echo "  [PASS] both plugin manifests at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null; then
+    echo "  [PASS] both plugin manifests at 0.21.0"
 else
-    echo "  [FAIL] plugin manifests not at 0.20.0"
+    echo "  [FAIL] plugin manifests not at 0.21.0"
     exit 1
 fi
 echo ""
 
-# Test 13: Marketplace entries at 0.20.0
+# Test 13: Marketplace entries at 0.21.0
 echo "Test 13: Marketplace entries..."
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "  [PASS] Claude marketplace workbench at 0.20.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "  [PASS] Claude marketplace workbench at 0.21.0"
 else
-    echo "  [FAIL] Claude marketplace workbench not at 0.20.0"
+    echo "  [FAIL] Claude marketplace workbench not at 0.21.0"
     exit 1
 fi
 echo ""

--- a/tests/unit/test-workbench-brainstorming-skill.sh
+++ b/tests/unit/test-workbench-brainstorming-skill.sh
@@ -70,13 +70,13 @@ TEMPLATE="$SKILL_DIR/references/brainstorm-summary-template.html"
 head -c 32 "$TEMPLATE" | grep -qiE '<!DOCTYPE|<html' || { echo "[FAIL] template malformed: $TEMPLATE"; exit 1; }
 echo "[PASS] em-dash + template checks"
 
-# Test 7: Plugin manifests at 0.20.0
+# Test 7: Plugin manifests at 0.21.0
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null; then
-    echo "[PASS] plugin manifests at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.21.0"
 else
-    echo "[FAIL] plugin manifests not at 0.20.0"; exit 1
+    echo "[FAIL] plugin manifests not at 0.21.0"; exit 1
 fi
 
 echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-copilot-skill.sh
+++ b/tests/unit/test-workbench-copilot-skill.sh
@@ -125,16 +125,16 @@ else
 fi
 echo ""
 
-# Test 10: Plugin manifests and marketplace at 0.20.0
-echo "Test 10: Plugin manifests and marketplace at 0.20.0..."
+# Test 10: Plugin manifests and marketplace at 0.21.0
+echo "Test 10: Plugin manifests and marketplace at 0.21.0..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null \
-   && jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "  [PASS] manifests and marketplace at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null \
+   && jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "  [PASS] manifests and marketplace at 0.21.0"
 else
-    echo "  [FAIL] workbench not at 0.20.0"; exit 1
+    echo "  [FAIL] workbench not at 0.21.0"; exit 1
 fi
 echo ""
 

--- a/tests/unit/test-workbench-crafting-design-systems-skill.sh
+++ b/tests/unit/test-workbench-crafting-design-systems-skill.sh
@@ -62,9 +62,9 @@ if grep -rqP '[\x{2014}\x{2013}]' "$SKILL_DIR"; then
 fi
 echo "[PASS]"
 
-echo "Test 10: workbench plugin version pinned to 0.20.0..."
-jq -e '.version == "0.20.0"' "$PLUGIN_JSON" > /dev/null \
-  || { echo "[FAIL] workbench plugin.json not at 0.20.0"; exit 1; }
+echo "Test 10: workbench plugin version pinned to 0.21.0..."
+jq -e '.version == "0.21.0"' "$PLUGIN_JSON" > /dev/null \
+  || { echo "[FAIL] workbench plugin.json not at 0.21.0"; exit 1; }
 echo "[PASS]"
 
 echo

--- a/tests/unit/test-workbench-crafting-html-skill.sh
+++ b/tests/unit/test-workbench-crafting-html-skill.sh
@@ -53,9 +53,9 @@ for skill in writing-spec writing-plans brainstorming systematic-debugging resea
 done
 echo "[PASS]"
 
-echo "Test 9: workbench plugin version pinned to 0.20.0..."
-jq -e '.version == "0.20.0"' "$PLUGIN_JSON" > /dev/null \
-  || { echo "[FAIL] workbench plugin.json not at 0.20.0"; exit 1; }
+echo "Test 9: workbench plugin version pinned to 0.21.0..."
+jq -e '.version == "0.21.0"' "$PLUGIN_JSON" > /dev/null \
+  || { echo "[FAIL] workbench plugin.json not at 0.21.0"; exit 1; }
 echo "[PASS]"
 
 echo

--- a/tests/unit/test-workbench-crafting-presentations-skill.sh
+++ b/tests/unit/test-workbench-crafting-presentations-skill.sh
@@ -78,9 +78,9 @@ if grep -rqP '[\x{2014}\x{2013}]' "$SKILL_DIR"; then
 fi
 echo "[PASS]"
 
-echo "Test 13: workbench plugin version pinned to 0.20.0..."
-jq -e '.version == "0.20.0"' "$PLUGIN_JSON" > /dev/null \
-  || { echo "[FAIL] workbench plugin.json not at 0.20.0"; exit 1; }
+echo "Test 13: workbench plugin version pinned to 0.21.0..."
+jq -e '.version == "0.21.0"' "$PLUGIN_JSON" > /dev/null \
+  || { echo "[FAIL] workbench plugin.json not at 0.21.0"; exit 1; }
 echo "[PASS]"
 
 echo

--- a/tests/unit/test-workbench-dispatching-parallel-agents-skill.sh
+++ b/tests/unit/test-workbench-dispatching-parallel-agents-skill.sh
@@ -57,17 +57,17 @@ fi
 
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null; then
-    echo "[PASS] plugin manifests at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.21.0"
 else
-    echo "[FAIL] plugin manifests not at 0.20.0"; exit 1
+    echo "[FAIL] plugin manifests not at 0.21.0"; exit 1
 fi
 
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "[PASS] Claude marketplace workbench at 0.20.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "[PASS] Claude marketplace workbench at 0.21.0"
 else
-    echo "[FAIL] Claude marketplace workbench not at 0.20.0"; exit 1
+    echo "[FAIL] Claude marketplace workbench not at 0.21.0"; exit 1
 fi
 
 echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-exporting-decks-to-pptx-skill.sh
+++ b/tests/unit/test-workbench-exporting-decks-to-pptx-skill.sh
@@ -98,16 +98,16 @@ for anchor in 'spcPct' 'wrap="none"' 'buChar' 'outerShdw' 'adjustments' 'est_lin
 done
 echo ""
 
-# Test 8: Plugin manifests and marketplace at 0.20.0
-echo "Test 8: Plugin manifests and marketplace at 0.20.0..."
+# Test 8: Plugin manifests and marketplace at 0.21.0
+echo "Test 8: Plugin manifests and marketplace at 0.21.0..."
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null \
-   && jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "  [PASS] manifests and marketplace at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null \
+   && jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "  [PASS] manifests and marketplace at 0.21.0"
 else
-    echo "  [FAIL] workbench not at 0.20.0"; exit 1
+    echo "  [FAIL] workbench not at 0.21.0"; exit 1
 fi
 echo ""
 

--- a/tests/unit/test-workbench-perfecting-presentations-skill.sh
+++ b/tests/unit/test-workbench-perfecting-presentations-skill.sh
@@ -81,9 +81,9 @@ if grep -rqP '[\x{2014}\x{2013}]' "$SKILL_DIR"; then
 fi
 echo "[PASS]"
 
-echo "Test 13: workbench plugin version pinned to 0.20.0..."
-jq -e '.version == "0.20.0"' "$PLUGIN_JSON" > /dev/null \
-  || { echo "[FAIL] workbench plugin.json not at 0.20.0"; exit 1; }
+echo "Test 13: workbench plugin version pinned to 0.21.0..."
+jq -e '.version == "0.21.0"' "$PLUGIN_JSON" > /dev/null \
+  || { echo "[FAIL] workbench plugin.json not at 0.21.0"; exit 1; }
 echo "[PASS]"
 
 echo

--- a/tests/unit/test-workbench-subagent-driven-development-skill.sh
+++ b/tests/unit/test-workbench-subagent-driven-development-skill.sh
@@ -73,17 +73,17 @@ done
 
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null; then
-    echo "[PASS] plugin manifests at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.21.0"
 else
-    echo "[FAIL] plugin manifests not at 0.20.0"; exit 1
+    echo "[FAIL] plugin manifests not at 0.21.0"; exit 1
 fi
 
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "[PASS] Claude marketplace workbench at 0.20.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "[PASS] Claude marketplace workbench at 0.21.0"
 else
-    echo "[FAIL] Claude marketplace workbench not at 0.20.0"; exit 1
+    echo "[FAIL] Claude marketplace workbench not at 0.21.0"; exit 1
 fi
 
 echo "=== Tests complete ==="

--- a/tests/unit/test-workbench-systematic-debugging-skill.sh
+++ b/tests/unit/test-workbench-systematic-debugging-skill.sh
@@ -84,16 +84,16 @@ pass "AGENTS.md mentions skill"
 grep -q "systematic-debugging" "$ROOT/plugins/workbench/NOTICE" || fail "NOTICE does not credit systematic-debugging"
 pass "NOTICE attribution present"
 
-# 13. Plugin manifests at 0.20.0.
+# 13. Plugin manifests at 0.21.0.
 CC_VER="$(jq -r '.version' "$ROOT/plugins/workbench/.claude-plugin/plugin.json")"
 CDX_VER="$(jq -r '.version' "$ROOT/plugins/workbench/.codex-plugin/plugin.json")"
-[ "$CC_VER" = "0.20.0" ] || fail "claude-plugin version is $CC_VER, expected 0.20.0"
-[ "$CDX_VER" = "0.20.0" ] || fail "codex-plugin version is $CDX_VER, expected 0.20.0"
-pass "plugin manifests at 0.20.0"
+[ "$CC_VER" = "0.21.0" ] || fail "claude-plugin version is $CC_VER, expected 0.21.0"
+[ "$CDX_VER" = "0.21.0" ] || fail "codex-plugin version is $CDX_VER, expected 0.21.0"
+pass "plugin manifests at 0.21.0"
 
-# 14. Claude marketplace entry at 0.20.0 (codex marketplace does not carry a per-plugin version field).
+# 14. Claude marketplace entry at 0.21.0 (codex marketplace does not carry a per-plugin version field).
 CC_MP_VER="$(jq -r '.plugins[] | select(.name=="workbench") | .version' "$ROOT/.claude-plugin/marketplace.json")"
-[ "$CC_MP_VER" = "0.20.0" ] || fail "claude marketplace workbench version is $CC_MP_VER, expected 0.20.0"
-pass "claude marketplace at 0.20.0"
+[ "$CC_MP_VER" = "0.21.0" ] || fail "claude marketplace workbench version is $CC_MP_VER, expected 0.21.0"
+pass "claude marketplace at 0.21.0"
 
 echo "OK"

--- a/tests/unit/test-workbench-test-driven-development-skill.sh
+++ b/tests/unit/test-workbench-test-driven-development-skill.sh
@@ -68,17 +68,17 @@ done
 
 CCM="$REPO_ROOT/plugins/workbench/.claude-plugin/plugin.json"
 CXM="$REPO_ROOT/plugins/workbench/.codex-plugin/plugin.json"
-if jq -e '.version == "0.20.0"' "$CCM" >/dev/null && jq -e '.version == "0.20.0"' "$CXM" >/dev/null; then
-    echo "[PASS] plugin manifests at 0.20.0"
+if jq -e '.version == "0.21.0"' "$CCM" >/dev/null && jq -e '.version == "0.21.0"' "$CXM" >/dev/null; then
+    echo "[PASS] plugin manifests at 0.21.0"
 else
-    echo "[FAIL] plugin manifests not at 0.20.0"; exit 1
+    echo "[FAIL] plugin manifests not at 0.21.0"; exit 1
 fi
 
 MP="$REPO_ROOT/.claude-plugin/marketplace.json"
-if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.20.0"' "$MP" >/dev/null; then
-    echo "[PASS] Claude marketplace workbench at 0.20.0"
+if jq -e '.plugins[] | select(.name == "workbench") | .version == "0.21.0"' "$MP" >/dev/null; then
+    echo "[PASS] Claude marketplace workbench at 0.21.0"
 else
-    echo "[FAIL] Claude marketplace workbench not at 0.20.0"; exit 1
+    echo "[FAIL] Claude marketplace workbench not at 0.21.0"; exit 1
 fi
 
 echo "=== Tests complete ==="


### PR DESCRIPTION
## Summary

Reviews all repo skills against Thariq Shihipar's AI Engineer talk (a field guide to working with the new Fable model class) and folds the actionable techniques into skill behavior. The talk's core is "find your unknowns before you prompt" (blind-spot pass, interviews, references-as-maps, implementation notes, quiz-before-PR) and "stop accepting fake trade-offs". Same-author lineage as the existing `learning` plugin (adapted from his "Learn Quiz" gist).

Each change was surfaced by a verification workflow (agents mapped every technique onto the skill inventory, then adversarially checked each proposal); motivational-only and already-covered ideas were dropped.

## Changes

**learning 0.1.0 -> 0.2.0**
- New skill `surveying-blind-spots`: agent-driven survey of an unfamiliar codebase area or field. Mines git history for pain (fix/revert/hack commits), TODO/FIXME comments, and conventions you would violate, then briefs you on unknown unknowns and hands back rewritten prompts. A briefing, not a quiz; sibling routing added so it does not misfire to `quizzing-a-topic`.
- `quizzing-the-session`: quiz-before-PR/merge framing (fixes a demonstrated misroute of reviewer-phrased prompts) plus reviewer-weighted checklist ordering.
- `quizzing-a-topic`: compute-over-recall rule so enumerable or version-sensitive answer keys are derived with a script or doc read, not recalled.

**workbench 0.20.0 -> 0.21.0**
- `brainstorming`: order design-tree branches by decision leverage; ask once for reference artifacts and treat a named artifact as the answer to every branch it settles; require a named forcing constraint before an either/or and price the combined option when only effort separates the choices; relay survey gotchas to a user new to the area; route stalled visual questions to divergent mockups.
- `visualizing-options`: new Divergent Directions section (3-4 different aesthetic poles when the user cannot articulate taste, converge after they react).
- `writing-spec`: record reference artifacts; every out-of-scope exclusion names what forces it out, with an explicit "cut for effort" label.
- `autopilot`/`copilot`: Deviation Log discipline, self-resolved forks and plan departures logged to scratch and surfaced in the end-of-turn summary.
- `subagent-driven-development`: implementation agents return a Deviations line; the orchestrator collects and reports them at Completion.

**agent-system-management 0.4.2 -> 0.4.3**
- `improving-instructions`: two new audit red flags and Common Issues entries for bare prohibitions and constraint accretion.
- `capturing-session-learnings`: capture prohibition-shaped learnings with their reason or alternative at write time.

## Not in scope (follow-up)

Embedded-question HTML screens in `visualizing-options` (the talk's "HTML report with questions embedded inside") is a real idea but reverses an explicit rule in that skill, so it is left for a separate decision.

## Test plan

- [x] Learning, workbench, agent-system-management unit suites pass (version pins updated in lockstep across manifests, both marketplaces, AGENTS.md, and all test pins)
- [x] Three live skill-triggering tests pass, including the previously-misrouting merge prompt
- [x] Frontmatter YAML lint, em-dash lint, and doc-invocation lints clean
